### PR TITLE
remove side-effects on operator module

### DIFF
--- a/autograd/grads.py
+++ b/autograd/grads.py
@@ -7,12 +7,12 @@ P = primitive
 
 # ----- Operator gradients -----
 I = lambda x : x # Identity operator
-op.neg = P(op.neg, lambda ans, x    : [op.neg])
-op.add = P(op.add, lambda ans, x, y : unbroadcast(ans, x, y, [I, I]))
-op.mul = P(op.mul, lambda ans, x, y : unbroadcast(ans, x, y, [lambda g : y * g, lambda g : x * g]))
-op.sub = P(op.sub, lambda ans, x, y : unbroadcast(ans, x, y, [I, op.neg]))
-op.div = P(op.div, lambda ans, x, y : unbroadcast(ans, x, y, [lambda g : g / y, lambda g : - g * x / y**2]))
-op.pow = P(op.pow, lambda ans, x, y : unbroadcast(ans, x, y, [lambda g : g * y * x ** (y - 1),
+neg = P(op.neg, lambda ans, x    : [op.neg])
+add = P(op.add, lambda ans, x, y : unbroadcast(ans, x, y, [I, I]))
+mul = P(op.mul, lambda ans, x, y : unbroadcast(ans, x, y, [lambda g : y * g, lambda g : x * g]))
+sub = P(op.sub, lambda ans, x, y : unbroadcast(ans, x, y, [I, op.neg]))
+div = P(op.div, lambda ans, x, y : unbroadcast(ans, x, y, [lambda g : g / y, lambda g : - g * x / y**2]))
+pow = P(op.pow, lambda ans, x, y : unbroadcast(ans, x, y, [lambda g : g * y * x ** (y - 1),
                                                               lambda g : g * np.log(x) * x ** y]))
 isarray = lambda x : isinstance(getval(x), np.ndarray)
 isfloat = lambda x : isinstance(getval(x), float)

--- a/autograd/node_types.py
+++ b/autograd/node_types.py
@@ -1,22 +1,22 @@
 import numpy as np
-import operator as op
 from abc import ABCMeta
 from core import Node, Setter, getval, zeros_like
+import grads
 
 class NumericNode(Node):
     __array_priority__ = 100.0 # Ensure precedence of Node's __rmul__ over numpy's __mul__
     __metaclass__ = ABCMeta
-    def __add__(self, other):   return op.add(self, other)
-    def __radd__(self, other):  return op.add(self, other)
-    def __sub__(self, other):   return op.sub(self, other)
-    def __rsub__(self, other):  return op.sub(other, self)
-    def __mul__(self, other):   return op.mul(self, other)
-    def __rmul__(self, other):  return op.mul(other, self)
-    def __neg__(self):          return op.neg(self)
-    def __pow__(self, power):   return op.pow(self, power)
-    def __rpow__(self, power):  return op.pow(power, self)
-    def __div__(self, other):   return op.div(self, other)
-    def __rdiv__(self, other):  return op.div(other, self)
+    def __add__(self, other):   return grads.add(self, other)
+    def __radd__(self, other):  return grads.add(self, other)
+    def __sub__(self, other):   return grads.sub(self, other)
+    def __rsub__(self, other):  return grads.sub(other, self)
+    def __mul__(self, other):   return grads.mul(self, other)
+    def __rmul__(self, other):  return grads.mul(other, self)
+    def __neg__(self):          return grads.neg(self)
+    def __pow__(self, power):   return grads.pow(self, power)
+    def __rpow__(self, power):  return grads.pow(power, self)
+    def __div__(self, other):   return grads.div(self, other)
+    def __rdiv__(self, other):  return grads.div(other, self)
     def __lt__(self, other):    return getval(self) < getval(other)
     def __gt__(self, other):    return getval(self) > getval(other) 
 


### PR DESCRIPTION
Importing autograd had side-effects on the `operator` module that I think were unnecessary. This PR removes that side-effect and edits `node_types.py` to import `grads.py` directly. All the tests seem to pass with this change.