### PR TITLE
separate forward and backward pass functions

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -5,7 +5,7 @@ import types
 import math
 import numpy as np
 
-def grad(fun,argnum=0):
+def grad(fun, argnum=0):
     """
     Returns a function which computes the gradient of `fun` with respect to
     positional argument number `argnum`. The returned function takes the same
@@ -24,7 +24,7 @@ def grad(fun,argnum=0):
 
     return gradfun
 
-def forward_pass(fun,args,kwargs,argnum=0):
+def forward_pass(fun, args, kwargs, argnum=0):
         tape = CalculationTape()
         arg_wrt = args[argnum]
         start_node = new_node(safe_type(getval(arg_wrt)), [tape])


### PR DESCRIPTION
This commit separates the forward and backward passes into functions. This change could make it [easier to evaluate Jacobians with a single forward pass](https://github.com/HIPS/autograd/blob/8ba4db62dc11b8dc6dd947864d63caad40c77256/autograd/convenience_wrappers.py#L47-48) (making them ~2x faster) and to make other additions that require access to the forward-pass-generated expression graph. It also makes the code a little more readable.