### PR TITLE
array promotion failure in primitive_sum_arrays

### DIFF
--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -116,7 +116,11 @@ def primitive_sum_arrays(*arrays):
         if isinstance(array, SparseArray):
             new_array[array.idx] += array.val
         else:
-            new_array += array
+            try:
+                new_array += array
+            except ValueError:
+                # broadcasting problem
+                new_array = new_array + array
     return new_array
 primitive_sum_arrays.gradmaker = lambda *args : lambda g : g
 


### PR DESCRIPTION
This test fails on master:

```python
import autograd.numpy as np
from autograd import grad

# btw these are not really the natural parameters (up to factors of -1/2)
def f(J,h):
    return -0.5*np.log(np.linalg.det(J)) + 0.5*np.dot(h,np.linalg.solve(J,h))

h = np.zeros(3.)
print grad(f)(-0.5*np.eye(3),h)
```

with an error like this

```
/Users/mattjj/Code/autograd/autograd/numpy/numpy_extra.py in primitive_sum_arrays(*arrays)
    117             new_array[array.idx] += array.val
    118         else:
--> 119             new_array += array
    120     return new_array
    121 primitive_sum_arrays.gradmaker = lambda *args : lambda g : g

ValueError: non-broadcastable output operand with shape () doesn't match the broadcast shape (3,3)
```

This commit attempts a very basic patch where it replaces that line of `primitive_sum_arrays` with a try/catch block that falls back to `new_array = new_array + array` on failure.