### PR TITLE
grad of np.linalg.solve can break from dimension-promotion problems

### DIFF
--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -5,8 +5,8 @@ from . import numpy_wrapper as anp
 
 wrap_namespace(npla.__dict__, globals())
 
-def atleast_2d(x):
-    # NOTE: promotes a 1D array into a column rather than a row
+def atleast_2d_col(x):
+    # Promotes a 1D array into a column rather than a row.
     return x if x.ndim > 1 else x[:,None]
 
 # Formulas from
@@ -16,7 +16,8 @@ def atleast_2d(x):
 # https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
 inv.defgrad(  lambda ans, x    : lambda g : -dot(dot(ans.T, g), ans.T))
 det.defgrad(  lambda ans, x    : lambda g : g * ans * inv(x).T)
-solve.defgrad(lambda ans, a, b : lambda g : -dot(atleast_2d(solve(a.T, g)), atleast_2d(ans).T))
+solve.defgrad(lambda ans, a, b : lambda g : -dot(atleast_2d_col(solve(a.T, g)),
+                                                 atleast_2d_col(ans).T))
 solve.defgrad(lambda ans, a, b : lambda g : solve(a.T, g), argnum=1)
 norm.defgrad( lambda ans, a    : lambda g : dot(g, a/ans))
 

--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -14,7 +14,7 @@ def atleast_2d(x):
 #  for forward and reverse mode algorithmic differentiation"
 # by Mike Giles
 # https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
-inv.defgrad(  lambda ans, x    : lambda g : -dot(dot(atleast_2d(ans).T, g), atleast_2d(ans).T))
+inv.defgrad(  lambda ans, x    : lambda g : -dot(dot(ans.T, g), ans.T))
 det.defgrad(  lambda ans, x    : lambda g : g * ans * inv(x).T)
 solve.defgrad(lambda ans, a, b : lambda g : -dot(atleast_2d(solve(a.T, g)), atleast_2d(ans).T))
 solve.defgrad(lambda ans, a, b : lambda g : solve(a.T, g), argnum=1)

--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -5,14 +5,18 @@ from . import numpy_wrapper as anp
 
 wrap_namespace(npla.__dict__, globals())
 
+def atleast_2d(x):
+    # NOTE: promotes a 1D array into a column rather than a row
+    return x if x.ndim > 1 else x[:,None]
+
 # Formulas from
 # "An extended collection of matrix derivative results
 #  for forward and reverse mode algorithmic differentiation"
 # by Mike Giles
 # https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
-inv.defgrad(  lambda ans, x    : lambda g : -dot(dot(ans.T, g), ans.T))
+inv.defgrad(  lambda ans, x    : lambda g : -dot(dot(atleast_2d(ans).T, g), atleast_2d(ans).T))
 det.defgrad(  lambda ans, x    : lambda g : g * ans * inv(x).T)
-solve.defgrad(lambda ans, a, b : lambda g : -dot(solve(a.T, g), ans.T))
+solve.defgrad(lambda ans, a, b : lambda g : -dot(atleast_2d(solve(a.T, g)), atleast_2d(ans).T))
 solve.defgrad(lambda ans, a, b : lambda g : solve(a.T, g), argnum=1)
 norm.defgrad( lambda ans, a    : lambda g : dot(g, a/ans))
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -22,6 +22,17 @@ def test_solve_arg1():
     check_grads(fun, A)
     check_grads(d_fun, A)
 
+def test_solve_arg1_1d():
+    D = 8
+    A = npr.randn(D, D) + 10.0 * np.eye(D)
+    B = npr.randn(D)
+    def fun(a): return to_scalar(np.linalg.solve(a, B))
+    d_fun = lambda x : to_scalar(grad(fun)(x))
+    check_grads(fun, A)
+    check_grads(d_fun, A)
+
+#return np.dot(b,np.dot(np.linalg.inv(A),b))
+
 def test_solve_arg2():
     D = 6
     A = npr.randn(D, D) + 1.0 * np.eye(D)


### PR DESCRIPTION
This doesn't work:

```python
import autograd.numpy as np
from autograd import grad

np.random.seed(0)

def f(A):
    return np.dot(b,np.linalg.solve(A,b))

def f2(A):
    return np.dot(b,np.dot(np.linalg.inv(A),b))

A = np.random.randn(2,2)
b = np.random.randn(2)

print f(A)
print f2(A)
print
print grad(f)(A)
print grad(f2)(A)
```

It prints this:

```
3.37428091778
3.37428091778

-2.54701989
[[-1.85497949  1.43978617]
 [ 0.89160513 -0.69204039]]
```

The latter is correct. The former doesn't even have the right dimension!

The problem is that the transposes used in [the gradient of `solve`](https://github.com/HIPS/autograd/blob/512506cc416516fb4e6c94babbcfb513f1b6bf9e/autograd/numpy/linalg.py#L15) are no-ops when applied to proper 1D vectors.

I think this pull request is a fix: it just adds calls to `atleast_2d` around the things that might be vectors getting transposed. Instead of using numpy's `atleast_2d` I instead added a version that promotes 1D arrays to columns instead of rows.

All current nose tests pass. This issue might deserve test coverage of its own but I haven't learned how to do that yet :).