### PR TITLE
einsum with alternate calling convention

### DIFF
--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -131,5 +131,11 @@ def test_einsum_ellipses():   combo_check(np.einsum, [1, 2], ['...jk,...lj->...l
 def test_einsum_three_args(): combo_check(np.einsum, [1, 2], ['ijk,lji,lli->lki'],
                                           [R(3, 4, 4)], [R(4, 4, 3)], [R(4, 4, 3)])
 
+def test_einsum2_transpose():  combo_check(np.einsum, [0], [R(1, 1), R(4,4), R(3,4)], [(0,1)], [(1,0)])
+def test_einsum2_matmult():    combo_check(np.einsum, [0, 2], [R(2, 3)], [(0,1)], [R(3,4)], [(1,2)], [(0,2)])
+def test_einsum2_covsum():     combo_check(np.einsum, [0, 2], [R(3, 4, 4)], [(0,1,2)], [R(4, 4, 3)], [(3,1,0)], [(3,2,0)])
+def test_einsum2_three_args(): combo_check(np.einsum, [0, 2],
+                                          [R(3, 4, 4)], [(0,1,2)], [R(4, 4, 3)], [(3,1,0)], [R(4, 4, 3)], [(3,3,0)], [(3,2,0)])
+
 def test_trace(): combo_check(np.trace, [0], [R(5, 5), R(4, 5), R(5, 4), R(3, 4, 5)], offset=[-1, 0, 1])
 def test_diag(): combo_check(np.diag, [0], [R(5, 5)], k=[-1, 0, 1])


### PR DESCRIPTION
gradient for einsum with calling convention "einsum(op0, sublist0, op1, sublist1, ..., [sublistout])", which I wound up needing for a project I'm working on.

Unfortunately it fails when sublistout contains a repeated index. But the implementation of the more common convention "einsum(subscripts, *operands)" also suffers from the same problem.