### PR TITLE
Fixed integer comparison in unbroadcast

### DIFF
--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -346,7 +346,7 @@ def unbroadcast(ans, x, gradfun):
             while anp.ndim(result) > len(shape):
                 result = anp.sum(result, axis=0)
             for axis, size in enumerate(shape):
-                if size is 1:
+                if size == 1:
                     result = anp.sum(result, axis=axis, keepdims=True)
             assert anp.shape(result) == shape
             return result


### PR DESCRIPTION
There is a minor bug in the numpy_grads.unbroadcast function due to the fact that array shapes are compared with the "is" operator instead of "==".  The former treats some dimensions as different that should actually be the same:

    In [325]: 1 is 1L
    Out[325]: False
    
    In [326]: 1 == 1L
    Out[326]: True

This caused assertion failures on line 351 for me and is the likely cause of #33 .