### PR TITLE
Adding dtype to autograd nodes

### DIFF
--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -30,6 +30,7 @@ class ArrayNode(Node):
     shape = property(lambda self: self.value.shape)
     ndim  = property(lambda self: self.value.ndim)
     size  = property(lambda self: self.value.size)
+    dtype = property(lambda self: self.value.dtype)
     T = property(lambda self: anp.transpose(self))
 
     def __len__(self):


### PR DESCRIPTION
I'm not sure if this breaks anything.  All tests pass and it's confusing to have no dtype attached to these nodes.