### PR TITLE
add recursive call to primitive_sum in container type sums

### DIFF
--- a/autograd/container_types.py
+++ b/autograd/container_types.py
@@ -137,12 +137,14 @@ def dict_untake(x, idx, template):
 dict_untake.defgrad(lambda ans, x, idx, template : lambda g : dict_take(g, idx))
 dict_untake.defgrad_is_zero(argnums=(1, 2))
 
+primitive_summers = {
+    list: primitive_sum_lists,
+    tuple: primitive_sum_tuples,
+    dict: primitive_sum_dicts,
+}
+
 def primitive_sum(container):
-    if isinstance(container[0], list):
-        return primitive_sum_lists(*container)
-    if isinstance(container[0], dict):
-        return primitive_sum_dicts(*container)
-    if isinstance(container[0], tuple):
-        return primitive_sum_tuples(*container)
-    else:
-        return sum(container[1:], container[0])
+    thetype = type(container[0])
+    if thetype in primitive_summers:
+        return primitive_summers[thetype](*container)
+    return sum(container[1:], container[0])

--- a/autograd/container_types.py
+++ b/autograd/container_types.py
@@ -3,6 +3,7 @@ from autograd.core import primitive, Node, getval, zeros_like, cast
 from six.moves import zip
 import six
 
+
 class TupleNode(Node):
     __slots__ = []
     def __getitem__(self, idx):
@@ -22,7 +23,7 @@ Node.type_mappings[tuple] = TupleNode
 
 @primitive
 def primitive_sum_tuples(*tuples):
-    return tuple([sum(elements[1:], elements[0]) for elements in zip(*tuples)])
+    return tuple([primitive_sum(elements) for elements in zip(*tuples)])
 primitive_sum_tuples.gradmaker = lambda *args : lambda g : g
 
 @primitive
@@ -67,7 +68,7 @@ Node.type_mappings[list] = ListNode
 
 @primitive
 def primitive_sum_lists(*lists):
-    return [sum(elements[1:], elements[0]) for elements in zip(*lists)]
+    return [primitive_sum(elements) for elements in zip(*lists)]
 primitive_sum_lists.gradmaker = lambda *args : lambda g : g
 
 @primitive
@@ -118,7 +119,7 @@ def primitive_sum_dicts(*dicts):
        Returns a new dict whose values are the sum over all input dicts."""
     # assert set(dicts[0]) == set(dicts[0]).intersection(*dicts)
     keys = dicts[0]
-    return {k : sum([dict[k] for dict in dicts]) for k in keys}
+    return {k : primitive_sum([dict[k] for dict in dicts]) for k in keys}
 primitive_sum_dicts.gradmaker = lambda *args : lambda g : g
 
 @primitive
@@ -135,3 +136,13 @@ def dict_untake(x, idx, template):
     return result
 dict_untake.defgrad(lambda ans, x, idx, template : lambda g : dict_take(g, idx))
 dict_untake.defgrad_is_zero(argnums=(1, 2))
+
+def primitive_sum(container):
+    if isinstance(container[0], list):
+        return primitive_sum_lists(*container)
+    if isinstance(container[0], dict):
+        return primitive_sum_dicts(*container)
+    if isinstance(container[0], tuple):
+        return primitive_sum_tuples(*container)
+    else:
+        return sum(container[1:], container[0])


### PR DESCRIPTION
Check this out:

```python
from autograd import grad

def f(tup):
    a, lst = tup
    x, y = lst
    return a+x+y

print grad(f)((1.,[2.,5.]))  # prints (1.0, [1.0, 1.0, 0.0, 0.0])
```

On the current master (3836fc2) that prints `(1.0, [1.0, 1.0, 0.0, 0.0])`, but I think it should print `(1.0, [1.0, 1.0])`.

I think the problem is essentially that the primitive sum functions for container types, like `primitive_sum_tuples`, don't recursively call other primitive sum functions, like `primitive_sum_lists`, and instead they just call regular `sum`, leading to the list concatenation above. 

One way to fix it, which this PR attempts, might be to make the primitive_sum functions recursively call a primitive summer that can handle all containers as well as non-containers.

All the tests pass on this branch, and it makes the above code produce `(1.0, [1.0, 1.0])` as expected. However, the code for `primitive_sum` could be cleaner and I don't have time to check things too thoroughly right now.