### PR TITLE
explicitly symmetrize cholesky gradient

### DIFF
--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -82,7 +82,7 @@ def make_grad_cholesky(L, A):
             dL[k+1:,k] /= L[k,k]
             dL[k,k] -= anp.dot(dL[k+1:,k], L[k+1:,k])
             dL[k,k] /= 2 * L[k,k]
-        return dL
+        return (dL + dL.T)/2.
 
     try:
         from .linalg_extra import cholesky_grad as cython_cholesky_grad

--- a/autograd/numpy/linalg_extra.pyx
+++ b/autograd/numpy/linalg_extra.pyx
@@ -27,4 +27,4 @@ def cholesky_grad(floating[:,:] L, floating[:,:] dL):
     cdef double[::1,:] _dL = np.require(np.tril(dL), np.double, 'F')
     cdef double[::1,:] _L = np.require(L, np.double, 'F')
     _cholesky_grad(_L, _dL)
-    return np.asarray(_dL)
+    return (np.asarray(_dL) + np.asarray(_dL).T)/2.

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -9,6 +9,13 @@ from builtins import range
 
 npr.seed(1)
 
+def check_symmetric_matrix_grads(fun, *args):
+    def symmetrize(A):
+        L = np.tril(A)
+        return (L + L.T)/2.
+    new_fun = lambda *args: fun(symmetrize(args[0]), *args[1:])
+    return check_grads(new_fun, *args)
+
 def test_inv():
     def fun(x): return to_scalar(np.linalg.inv(x))
     d_fun = lambda x : to_scalar(grad(fun)(x))
@@ -120,18 +127,12 @@ def test_eigvalh_upper():
     check_grads(d_fun, hmat)
 
 def test_cholesky():
-    # we write a test function that explicitly symmetrizes because otherwise
-    # cholesky only reads from the lower triangle and hence the numerical
-    # gradient is lower triangular
-    def symmetrize(A):
-        L = np.tril(A)
-        return (L + L.T)/2.
     def fun(A):
-        return to_scalar(np.linalg.cholesky(symmetrize(A)))
+        return to_scalar(np.linalg.cholesky(A))
     def rand_psd(D):
         mat = npr.randn(D,D)
         return np.dot(mat, mat.T)
-    check_grads(fun, rand_psd(6))
+    check_symmetric_matrix_grads(fun, rand_psd(6))
 
 def test_sqrtm():
     def fun(A):
@@ -139,7 +140,7 @@ def test_sqrtm():
     def rand_psd(D):
         mat = npr.randn(D,D)
         return np.dot(mat, mat.T)
-    check_grads(fun, rand_psd(6))
+    check_symmetric_matrix_grads(fun, rand_psd(6))
 
 def test_solve_triangular_arg1():
     D = 6

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -120,14 +120,18 @@ def test_eigvalh_upper():
     check_grads(d_fun, hmat)
 
 def test_cholesky():
+    # we write a test function that explicitly symmetrizes because otherwise
+    # cholesky only reads from the lower triangle and hence the numerical
+    # gradient is lower triangular
+    def symmetrize(A):
+        L = np.tril(A)
+        return (L + L.T)/2.
     def fun(A):
-        return to_scalar(np.linalg.cholesky(A))
-    d_fun = lambda A: to_scalar(grad(fun)(A))
+        return to_scalar(np.linalg.cholesky(symmetrize(A)))
     def rand_psd(D):
         mat = npr.randn(D,D)
         return np.dot(mat, mat.T)
     check_grads(fun, rand_psd(6))
-    # check_grads(d_fun, rand_psd(6))
 
 def test_sqrtm():
     def fun(A):


### PR DESCRIPTION
I think the cholesky gradient is not quite the one we want. It agrees with the numerical gradient, but that numerical gradient is always lower-triangular (with zeros on the strict upper triangle) because the cholesky routine only reads the lower triangle of its input matrix. 

Here are two routines for computing log det on positive definite matrices via the cholesky decomposition. The correct gradient is matrix inverse:

```python
def plogdet(X):
    L = np.linalg.cholesky(X)
    return 2*np.sum(np.log(np.diag(L)))


def symmetrized_plogdet(X):
    L = np.linalg.cholesky((X + X.T)/2.)
    return 2*np.sum(np.log(np.diag(L)))


def rand_psd(n):
    temp = np.random.randn(n, n)
    return np.dot(temp, temp.T)


X = rand_psd(3)
print grad(plogdet)(X)
print grad(symmetrized_plogdet)(X)
print np.linalg.inv(X)
```

It prints this:

```python
[[ 0.72177037  0.          0.        ]
 [ 0.30910372  0.53462302  0.        ]
 [-0.00390117  0.3101816   0.39732965]]
[[ 0.72177037  0.15455186 -0.00195059]
 [ 0.15455186  0.53462302  0.1550908 ]
 [-0.00195059  0.1550908   0.39732965]]
[[ 0.72177037  0.15455186 -0.00195059]
 [ 0.15455186  0.53462302  0.1550908 ]
 [-0.00195059  0.1550908   0.39732965]]
```

As you can see, the logdet which explicitly symmetrizes its argument before calling Cholesky gives us the version we might expect. (An even better symmetrization would call np.tril first to allow the upper triangle of the input matrix to be junk, which is how the gradient is actually handled in this PR.)

I think switching to a cholesky grad that returns a symmetric matrix has the least surprising behavior, **but** the lower-triangular gradient currently in master is also 'correct' because the cholesky really does read only from the lower triangle of its input. This PR makes the switch to the symmetric version in both the python and cython implementations as well as the test (which passes for both code paths).