### PR TITLE
make Node have same falseyness as underlying value

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -214,6 +214,11 @@ class Node(object):
             tape.append(new_rnode)
             self.tapes[tape] = new_rnode
 
+    def __bool__(self):
+        return bool(self.value)
+
+    __nonzero__ = __bool__
+
     @staticmethod
     def sum_outgrads(outgrads):
         return sum(outgrads[1:], outgrads[0])

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -57,6 +57,8 @@ anp.iscomplex.defgrad_is_zero()
 anp.nan_to_num.defgrad_is_zero()
 anp.size.defgrad_is_zero()
 anp.where.defgrad_is_zero(argnums=(0,))
+anp.isscalar.defgrad_is_zero()
+anp.isreal.defgrad_is_zero()
 
 # ----- Binary ufuncs -----
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,43 @@
+from __future__ import division
+import autograd.numpy as np
+from autograd import grad
+from autograd.util import *
+
+def test_assert():
+    # from https://github.com/HIPS/autograd/issues/43
+    def fun(x):
+        assert np.allclose(x, (x*3.0)/3.0)
+        return np.sum(x)
+    check_grads(fun, np.array([1.0, 2.0, 3.0]))
+
+def test_nograd():
+    # we want this to raise non-differentiability error
+    fun = lambda x: np.allclose(x, (x*3.0)/3.0)
+    try:
+        grad(fun)(np.array([1., 2., 3.]))
+    except TypeError:
+        pass
+    else:
+        raise Exception('Expected non-differentiability exception')
+
+def test_falseyness():
+    fun = lambda x: x**2 if np.isscalar(x) else np.sum(x)
+    check_grads(fun, 5.)
+    check_grads(fun, np.array([1., 2.]))
+
+def test_unimplemented_falseyness():
+    def remove_grad_definitions(fun):
+        grads, zero_grads = fun.grads, fun.zero_grads
+        fun.grads, fun.zero_grads = {}, set()
+        return grads, zero_grads
+
+    def restore_grad_definitions(fun, grad_defs):
+        fun.grads, fun.zero_grads = grad_defs
+
+    grad_defs = remove_grad_definitions(np.isscalar)
+
+    fun = lambda x: x**2 if np.isscalar(x) else np.sum(x)
+    check_grads(fun, 5.)
+    check_grads(fun, np.array([1., 2.]))
+
+    restore_grad_definitions(np.isscalar, grad_defs)


### PR DESCRIPTION
We want Nodes to inherit the falseyness of their underlying values so that boxed values can be used in Python logic.

There was a certain pathology that could arise here when a numpy boolean-valued function was wrapped as primitive but didn't have a gradient implemented. The pathology would happen with a function like this one:

```python
def foo(x):
    if np.isscalar(x):  # gradient of np.isscalar isn't implemented in current master
        return x**2
    else:
        return np.sum(x)

grad(foo)(np.array([1., 2.]))  # does the wrong thing!
```

The problem is that np.isscalar(x) returns a Node wrapping the underlying False value, and since Python's default is to treat any object without a `__nonzero__` or `__bool__` as True, the forward execution is wrong. This problem won't happen when the function has a zero gradient, i.e. from calling `anp.isscalar.defgrad_is_zero()` in `numpy_grads.py` as is done for most of the other numpy test functions, because on the forward pass [zero gradients are handled in a special way](https://github.com/HIPS/autograd/blob/3ec5fc078687eef41d41b3efa14069e21b4f3eb9/autograd/core.py#L154)

This exact problem also didn't happen before my fix to #43 (e.g. on commit fc3058c) because in that case a different error would be raised on the forward pass, namely the "Can't differentiate wrt type 'bool'". That behavior isn't desirable, but at least it blew up (for a different reason) instead of failing silently.

The right solution is for all Nodes to inherit the falseyness of their underlying values. That just means implementing simple `__bool__` and `__nonzero__` methods in the Node class:

```python
    def __bool__(self):
        return bool(self.value)

    __nonzero__ = __bool__
```

This PR should handle all the problems, and more importantly it adds several tests in `test_logic.py` to cover all the cases I described above. In particular, it tests both the implemented (zero grad) case and the unimplemented grad case, and also adds a test for the assert logic from #43.