### PR TITLE
add gradient for np.tile, add support for sum axis tuple

### DIFF
--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -170,6 +170,12 @@ def make_grad_repeat(ans, x, repeats, axis=None):
             return grad_repeat
 anp.repeat.defgrad(make_grad_repeat)
 
+def make_grad_tile(ans, x, reps):
+    reshape = lambda g: anp.reshape(g, sum(zip(x.shape, tuple(reps)), ()))
+    sum_alternating_dims = lambda g: anp.sum(g, tuple(range(1, len(g.shape), 2)))
+    return lambda g: sum_alternating_dims(reshape(g))
+anp.tile.defgrad(make_grad_tile)
+
 def make_grad_transpose(ans, x, axes=None):
     if axes is not None:
         axes = anp.argsort(axes)
@@ -181,6 +187,8 @@ isarray = lambda x : isinstance(getval(x), anp.ndarray)
 def repeat_to_match_shape(x, axis, keepdims):
     """Returns a function that repeats an array along axis to get a given shape.
        Also returns the number of repetitions of the array."""
+    assert isinstance(axis, (type(None), int, tuple))
+
     if not isarray(x):
         return I, 1
     shape = x.shape
@@ -192,12 +200,21 @@ def repeat_to_match_shape(x, axis, keepdims):
             return lambda g : anp.full(shape, anp.sum(g), dtype=dtype), anp.prod(shape)
         else:
             return lambda g : anp.full(shape, g, dtype=dtype), anp.prod(shape)
-    else:
+    elif isinstance(axis, int):
         if keepdims:
             return lambda g : anp.repeat(g, shape[axis], axis), shape[axis]
         else:
             return lambda g : anp.repeat(anp.expand_dims(g, axis),
                                          shape[axis], axis), shape[axis]
+    else:
+        repeats  = [shape[i] if i in axis else 1 for i in range(len(shape))]
+        expanded = [shape[i] if i not in axis else 1 for i in range(len(shape))]
+        num_reps = anp.prod(anp.array(shape)[list(axis)])
+
+        if keepdims:
+            return lambda g: anp.tile(g, repeats), num_reps
+        else:
+            return lambda g: anp.tile(anp.reshape(g, expanded), repeats), num_reps
 
 def make_grad_np_sum(ans, x, axis=None, keepdims=False):
     repeater, _ = repeat_to_match_shape(x, axis, keepdims)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -137,6 +137,13 @@ def test_sum_3():
     check_grads(fun, mat)
     check_grads(d_fun, mat)
 
+def test_sum_axis_tuple():
+    fun = lambda x: to_scalar(np.sum(x, (0,1)))
+    d_fun = lambda x: to_scalar(grad(fun)(x))
+    mat = npr.randn(3,4,5)
+    check_grads(fun, mat)
+    check_grads(d_fun, mat)
+
 def test_flipud():
     def fun(x): return to_scalar(np.flipud(x))
     d_fun = lambda x : to_scalar(grad(fun)(x))

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -86,6 +86,10 @@ def test_transpose(): combo_check(np.transpose, [0],
 def test_repeat(): combo_check(np.repeat, [0], [R(2, 3, 4), R(3, 1)],
                                repeats=[0,1,2], axis = [None, 0, 1])
 
+def test_tile():
+    combo_check(np.tile, [0], [R(3,1,3)], reps=[(1,3,1)])
+    combo_check(np.tile, [0], [R(2,1,3,1)], reps=[(1, 4, 1, 2)])
+
 def test_dot(): combo_check(np.dot, [0, 1],
                             [1.5, R(3), R(2, 3)],
                             [0.3, R(3), R(3, 4)])


### PR DESCRIPTION
Added a gradient for `np.tile` and support for calls to `np.sum` where the axis argument is a tuple, like `np.sum(x, axis=(0,1))`.

I made this a PR so travis will tell me if Python3 works.