### PR TITLE
BLD: conda recipe for anaconda.org support

### DIFF
--- a/conda_recipe/conda.yaml
+++ b/conda_recipe/conda.yaml
@@ -1,0 +1,38 @@
+package:
+  name: autograd
+  # there are ways to derive version from other sources; for now, it's hard-coded
+  version: 1.1.1
+
+source:
+  {% if not environ.get('BINSTAR_PLATFORM', None) %}
+  git_url: ../
+  {% else %}
+  # we're building on binstar, we already have the repo; treat as local path
+  path: ../
+  {% endif %}
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - future
+    - numpy >=1.9
+
+  run:
+    - python
+    - future
+    - numpy >=1.9
+
+build:
+  script: python setup.py build && python setup.py install
+
+test:
+  # Python imports
+  imports:
+    - autograd
+    - autograd.numpy
+
+about:
+  home: https://github.com/HIPS/autograd
+  license: MIT
+  summary: 'Efficiently computes derivatives of numpy code.'


### PR DESCRIPTION
This PR adds the ability to build conda packages for https://anaconda.org. Since autograd is pure Python, this is really easy.

Uploading to Anaconda.org
-------------------------
Start with the commit checked out which was tagged with the new version. If conda.yaml has a hard-coded version, the version change should already be committed.

1. ``rm /path/to/anaconda/conda-bld/linux-64/autograd-*.tar.bz2`` on Linux/OSX (use ``del`` and correct path on Windows)
2. ``rm -R dist/*`` on Linux/OSX or ``del dist/*`` on Windows
3. ``conda build --python 2.7 conda_recipe/``

   ``conda build --python 3.3 conda_recipe/``

   ``conda build --python 3.4 conda_recipe/``

   ``conda build --python 3.5 conda_recipe/``

4. ``conda convert --platform all /path/to/anaconda/conda-bld/linux-64/autograd-*.tar.bz2 -o ./dist``
5. ``anaconda upload -u [username] dist/*/*``

The `/path/to/...` may be slightly different.depending on your platform. `[username]` is your anaconda.org username. Here is the result when I upload autograd to my anaconda.org channel: https://anaconda.org/richardotis/autograd . Note that https://anaconda.org/richardotis/autograd/files has platform-specific files uploaded, though in this case they'll all contain the same thing since we built a pure Python package.