### PR TITLE
give grad the ability to take derivative wrt all arguments

### DIFF
--- a/autograd/__init__.py
+++ b/autograd/__init__.py
@@ -2,4 +2,5 @@ from __future__ import absolute_import
 from .core import grad, primitive, jacobian
 from . import container_types
 from .convenience_wrappers import (multigrad, elementwise_grad, value_and_grad,
-                                  grad_and_aux, hessian_vector_product, hessian)
+                                  grad_and_aux, hessian_vector_product, hessian,
+                                  multigrad_dict)

--- a/autograd/__init__.py
+++ b/autograd/__init__.py
@@ -2,5 +2,4 @@ from __future__ import absolute_import
 from .core import grad, primitive, jacobian
 from . import container_types
 from .convenience_wrappers import (multigrad, elementwise_grad, value_and_grad,
-                                  grad_and_aux, hessian_vector_product, hessian,
-                                  multigrad_dict)
+                                  grad_and_aux, hessian_vector_product, hessian)

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -16,6 +16,11 @@ def multigrad(fun, argnums=[0]):
         return gradfun(multi_arg, *args, **kwargs)
     return gradfun_rearranged
 
+def multigrad_dict(fun):
+    "Takes gradients wrt all arguments simultaneously,"
+    "returns a dict mapping 'argname' to 'gradval'"
+    return grad(fun, None)
+
 def grad_and_aux(fun, argnum=0):
     """Builds a function that returns the gradient of the first output and the
     (unmodified) second output of a function that returns two outputs."""

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -1,8 +1,7 @@
 """Convenience functions built on top of `grad`."""
 from __future__ import absolute_import
 import autograd.numpy as np
-from autograd.core import grad, getval, jacobian
-
+from autograd.core import grad, jacobian, getval, primitive
 
 def multigrad(fun, argnums=[0]):
     """Takes gradients wrt multiple arguments simultaneously."""
@@ -16,6 +15,27 @@ def multigrad(fun, argnums=[0]):
         multi_arg = tuple([args[i] for i in argnums])
         return gradfun(multi_arg, *args, **kwargs)
     return gradfun_rearranged
+
+def multigrad_dict(fun):
+    """By default, takes gradients with respect to all arguments, returns them
+    in a dict that maps 'argname' to 'gradval'."""
+    def getcallargs(fun,*args,**kwargs):
+        if isinstance(fun,primitive):
+            fun = fun.fun
+        return inspect.getcallargs(fun, *args, **kwargs)
+
+    return lambda *args, **kwargs: \
+        grad(lambda dct: fun(**dct))(getcallargs(fun, *args, **kwargs))
+
+def getargspec(fun):
+    if isinstance(fun,primitive):
+        fun = fun.fun
+    return inspect.getargspec(fun)
+
+def getcallargs(fun,*args,**kwargs):
+    if isinstance(fun,primitive):
+        fun = fun.fun
+    return inspect.getcallargs(fun,*args,**kwargs)
 
 def grad_and_aux(fun, argnum=0):
     """Builds a function that returns the gradient of the first output and the

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -1,7 +1,7 @@
 """Convenience functions built on top of `grad`."""
 from __future__ import absolute_import
 import autograd.numpy as np
-from autograd.core import grad, jacobian, getval, primitive
+from autograd.core import grad, getval, jacobian
 
 def multigrad(fun, argnums=[0]):
     """Takes gradients wrt multiple arguments simultaneously."""
@@ -15,27 +15,6 @@ def multigrad(fun, argnums=[0]):
         multi_arg = tuple([args[i] for i in argnums])
         return gradfun(multi_arg, *args, **kwargs)
     return gradfun_rearranged
-
-def multigrad_dict(fun):
-    """By default, takes gradients with respect to all arguments, returns them
-    in a dict that maps 'argname' to 'gradval'."""
-    def getcallargs(fun,*args,**kwargs):
-        if isinstance(fun,primitive):
-            fun = fun.fun
-        return inspect.getcallargs(fun, *args, **kwargs)
-
-    return lambda *args, **kwargs: \
-        grad(lambda dct: fun(**dct))(getcallargs(fun, *args, **kwargs))
-
-def getargspec(fun):
-    if isinstance(fun,primitive):
-        fun = fun.fun
-    return inspect.getargspec(fun)
-
-def getcallargs(fun,*args,**kwargs):
-    if isinstance(fun,primitive):
-        fun = fun.fun
-    return inspect.getcallargs(fun,*args,**kwargs)
 
 def grad_and_aux(fun, argnum=0):
     """Builds a function that returns the gradient of the first output and the

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function
 import sys
 import warnings
-import copy
 import operator as op
 import types
 import math

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -109,7 +109,7 @@ def backward_pass(start_node, end_node, tape, return_type):
         return grad_dict if return_type == dict else tuple(grad_dict.values())
 
 def replace_args_with_nodes(fun, args, kwargs, argnum, argname, tape):
-    makenode = lambda argval: new_node(safe_type(getval(argval)), [tape])
+    makenode = lambda argval: merge_tapes(new_node(safe_type(getval(argval)), [tape]), argval)
     sig = funcsigs.signature(fun)
 
     if argname is not None:
@@ -118,7 +118,7 @@ def replace_args_with_nodes(fun, args, kwargs, argnum, argname, tape):
         return replace_args_with_nodes(fun, args, kwargs, argnum, None, tape)
     elif argnum is not None and argnum >= 0:
         new_args = list(args)
-        new_args[argnum] = node = merge_tapes(makenode(args[argnum]), args[argnum])
+        new_args[argnum] = node = makenode(args[argnum])
         bindings = sig.bind(*new_args, **kwargs)
         return node, bindings.args, bindings.kwargs, None
     else:

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -9,16 +9,21 @@ import numpy as np
 from functools import partial
 from future.utils import iteritems, raise_from, raise_
 from collections import defaultdict
+import funcsigs
 
-def grad(fun, argnum=0):
+def grad(fun, argnum=0, argname=None):
     """
     Returns a function which computes the gradient of `fun` with respect to
-    positional argument number `argnum`. The returned function takes the same
-    arguments as `fun`, but returns the gradient instead. The function `fun`
-    should be scalar-valued. The gradient has the same type as the argument."""
+    positional argument number `argnum` or argname `argname`. The returned
+    function takes the same arguments as `fun`, but returns the gradient
+    instead. The function `fun` should be scalar-valued. The gradient has the
+    same type as the argument."""
+    if (argnum is not None) and (argname is not None):
+        raise ValueError("Specify 'argnum' OR 'argname' (not both).")
+
     @attach_name_and_doc(fun, argnum, 'Gradient')
     def gradfun(*args,**kwargs):
-        return backward_pass(*forward_pass(fun,args,kwargs,argnum))
+        return backward_pass(*forward_pass(fun,args,kwargs,argnum,argname))
     return gradfun
 
 def jacobian(fun, argnum=0):
@@ -53,20 +58,22 @@ def jacobian(fun, argnum=0):
         return np.reshape(concatenate(grads), shape) if shape else grads[0]
     return gradfun
 
-def forward_pass(fun, args, kwargs, argnum=0):
-        tape = CalculationTape()
-        arg_wrt = args[argnum]
-        start_node = new_node(safe_type(getval(arg_wrt)), [tape])
-        args = list(args)
-        args[argnum] = merge_tapes(start_node, arg_wrt)
-        try: end_node = fun(*args, **kwargs)
-        except Exception as e: add_extra_error_message(e)
-        return start_node, end_node, tape
+def forward_pass(fun, args, kwargs, argnum=None, argname=None):
+    tape = CalculationTape()
+    start_nodes, args, kwargs = replace_args_with_nodes(fun, args, kwargs, argnum, argname, tape)
+    try: end_node = fun(*args, **kwargs)
+    except Exception as e: add_extra_error_message(e)
+    return start_nodes, end_node, tape
 
-def backward_pass(start_node, end_node, tape):
+def backward_pass(start_nodes, end_node, tape):
+    def unpack_result(grad_dict):
+        return grad_dict if len(grad_dict) > 1 else list(grad_dict.values())[0]
+
     if not isinstance(end_node, Node) or tape not in end_node.tapes:
         warnings.warn("Output seems independent of input. Returning zero gradient.")
-        return zeros_like(start_node)
+        grad_dict = {argname:zeros_like(start_node)
+                     for argname, start_node in iteritems(start_nodes)}
+        return unpack_result(grad_dict)
     if type(end_node) is not FloatNode:
         try:
             end_node = FloatNode.cast(end_node, 1.0)
@@ -75,22 +82,43 @@ def backward_pass(start_node, end_node, tape):
                             + "Function grad requires a scalar-valued function. "
                               "Try jacobian or elementwise_grad.")
 
-    for node in tape:
-        node.outgrads = []
+    tape.complete = True
+    for rnode in tape:
+        rnode.outgrads = []
     end_node.tapes[tape].outgrads = [1.0]
 
-    tape.complete = True
-    tape = copy.copy(tape)
-    while tape:
-        node = tape.pop()
-        if node.outgrads:
-            cur_outgrad = node.sum_outgrads()
-            assert type(new_node(getval(cur_outgrad))) == node.node_type, \
-                "Types are {0} and {1}".format(type(new_node(getval(cur_outgrad))), node.node_type)
-            for gradfun, parent in node.parent_grad_ops:
+    op_list = list(tape)
+    grad_dict = {}
+    start_rnodes = {node.tapes[tape]: argname for argname, node in iteritems(start_nodes)}
+    while op_list:
+        rnode = op_list.pop()
+        if rnode.outgrads:
+            cur_outgrad = rnode.sum_outgrads()
+            assert type(new_node(getval(cur_outgrad))) == rnode.node_type, \
+                "Types are {0} and {1}".format(type(new_node(getval(cur_outgrad))), rnode.node_type)
+            for gradfun, parent in rnode.parent_grad_ops:
                 og = cast_to_node_type(gradfun(cur_outgrad), parent.node_type, parent.node_value)
                 parent.outgrads.append(og)
-    return cur_outgrad
+            if rnode in start_rnodes:
+                grad_dict[start_rnodes[rnode]] = cur_outgrad
+    return unpack_result(grad_dict)
+
+def replace_args_with_nodes(fun, args, kwargs, argnum, argname, tape):
+    makenode = lambda argval: new_node(safe_type(getval(argval)), [tape])
+    sig = funcsigs.signature(fun)
+    argnames = list(sig.parameters)
+
+    if argnum is not None:
+        new_args = list(args)
+        new_args[argnum] = node = merge_tapes(makenode(args[argnum]), args[argnum])
+        bindings = sig.bind(*new_args, **kwargs)
+        return {argnames[argnum]: node}, bindings.args, bindings.kwargs
+    elif argname is not None:
+        argnum = argnames.index(argname)
+        return replace_args_with_nodes(fun, args, kwargs, argnum, None, tape)
+    else:
+        # replace all arguments
+        raise NotImplementedError
 
 def attach_name_and_doc(fun, argnum, opname):
     namestr = "{op}_{fun}_wrt_argnum_{argnum}".format(

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -113,8 +113,7 @@ def replace_args_with_nodes(fun, args, kwargs, argnum, argname, tape):
     sig = funcsigs.signature(fun)
 
     if argname is not None:
-        argnames = list(sig.parameters)
-        argnum = argnames.index(argname)
+        argnum = list(sig.parameters).index(argname)
         return replace_args_with_nodes(fun, args, kwargs, argnum, None, tape)
     elif argnum is not None and argnum >= 0:
         new_args = list(args)

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -106,6 +106,13 @@ def backward_pass(start_nodes, end_node, tape):
 def replace_args_with_nodes(fun, args, kwargs, argnum, argname, tape):
     makenode = lambda argval: new_node(safe_type(getval(argval)), [tape])
     sig = funcsigs.signature(fun)
+
+    # TODO the problem with argnames is that not all arguments have names!
+    # if the def looks like fun(*args), then there's no name to get
+    # => returning a grad_dict is a bad design
+
+    # so what should we do here? it makes sense to ask for argnum=0 or argnum=1
+    # even though they don't have names
     argnames = list(sig.parameters)
 
     if argnum is not None:

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     author='Dougal Maclaurin and David Duvenaud and Matthew Johnson',
     author_email="maclaurin@physics.harvard.edu, dduvenaud@seas.harvard.edu, mattjj@csail.mit.edu",
     packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats'],
-    install_requires=['numpy>=1.9', 'future'],
+    install_requires=['numpy>=1.9', 'future', 'funcsigs'],
     setup_requires=['numpy>=1.9'],
     keywords=['Automatic differentiation', 'backpropagation', 'gradients',
               'machine learning', 'optimization', 'neural networks',

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -3,7 +3,8 @@ import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd.util import *
 from autograd import (grad, elementwise_grad, jacobian, value_and_grad,
-                      grad_and_aux, hessian_vector_product, hessian, multigrad)
+                      grad_and_aux, hessian_vector_product, hessian, multigrad,
+                      multigrad_dict)
 from builtins import range
 
 npr.seed(1)
@@ -42,6 +43,23 @@ def test_multigrad_onearg():
     packed_fun = lambda xy: np.sum(xy[0] + np.sin(xy[1]))
     A, B = npr.randn(3), npr.randn(3)
     check_equivalent(multigrad(fun)(A,B), grad(packed_fun)((A,B)))
+
+def test_multigrad_dict():
+    def complicated_fun(a,b,c,d,e,f=1.1, g=9.0):
+        return a + np.sin(b) + np.cosh(c) + np.cos(d) + np.tan(e) + f + g
+
+    A = 0.5
+    B = -0.3
+    C = 0.2
+    D = -1.1
+    E = 0.7
+    F = 0.6
+    G = -0.1
+
+    gradtuple = multigrad(complicated_fun)(A, B, C, D, E, f=F, g=G)
+    graddict = multigrad_dict(complicated_fun)(A, B, C, D, E, f=F, g=G)
+    for val, key in zip(gradtuple, ['a', 'b', 'c', 'd', 'e', 'f', 'g']):
+        assert np.isclose(graddict[key], val)
 
 def test_elementwise_grad():
     def simple_fun(a):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd.util import *
-from autograd import (grad, elementwise_grad, jacobian, value_and_grad,
-                      grad_and_aux, hessian_vector_product, hessian, multigrad,
-                      multigrad_dict)
+from autograd import grad, elementwise_grad, hessian, multigrad
 from builtins import range
 
 npr.seed(1)
@@ -43,23 +41,6 @@ def test_multigrad_onearg():
     packed_fun = lambda xy: np.sum(xy[0] + np.sin(xy[1]))
     A, B = npr.randn(3), npr.randn(3)
     check_equivalent(multigrad(fun)(A,B), grad(packed_fun)((A,B)))
-
-def test_multigrad_dict():
-    def complicated_fun(a,b,c,d,e,f=1.1, g=9.0):
-        return a + np.sin(b) + np.cosh(c) + np.cos(d) + np.tan(e) + f + g
-
-    A = 0.5
-    B = -0.3
-    C = 0.2
-    D = -1.1
-    E = 0.7
-    F = 0.6
-    G = -0.1
-
-    gradtuple = multigrad(complicated_fun)(A, B, C, D, E, f=F, g=G)
-    graddict = multigrad_dict(complicated_fun)(A, B, C, D, E, f=F, g=G)
-    for val, key in zip(gradtuple, ['a', 'b', 'c', 'd', 'e', 'f', 'g']):
-        assert np.isclose(graddict[key], val)
 
 def test_elementwise_grad():
     def simple_fun(a):


### PR DESCRIPTION
Another experiment!

There is a function called `multigrad` in convenience_wrappers.py that provides a mechanism for taking the gradient with respect to multiple arguments. You give it `multigrad(fun, argnums=[0,2])` and it returns a tuple with the gradients of `fun` with respect to the first and third arguments.

This PR adds somewhat analogous functionality into `grad`, making it able to return OrderedDicts of grads. **All the existing behavior is the same**: if you call `grad` with any `argnum` that is not `None`, the code that executes [is identical](https://github.com/HIPS/autograd/blob/4df75e2b81cd3a6ae6e53f322b1027d4f6799978/autograd/core.py#L118-L122).

In addition to keeping the old behavior, `grad` learned two new things. It can take derivatives with respect to an argument name:

```python
In [1]: from autograd import grad

In [2]: def f(x, y, z):
    return x*y+z
   ...:

In [3]: grad(f, argname='x')(1.,2.,3.)
Out[3]: 2.0

In [4]: grad(f, argname='y')(1.,2.,3.)
Out[4]: 1.0

In [5]: grad(f, argname='z')(1.,2.,3.)
Out[5]: 1.0
```

And it can return an OrderedDict of gradients when `argnum=None` (and `argname=None`, the default):

```python
In [7]: grad(f, None)(1.,2.,3.)
Out[7]: OrderedDict([('x', 2.0), ('y', 1.0), ('z', 1.0)])
```

I tried to write this as a convenience wrapper first, but it got complicated because we can't splat `DictNode`s (i.e. call `foo(**dct)` when `dct` is a `DictNode`) due to the fact that they don't inherit from `dict`. Furthermore, packaging each argument into its own Node (as opposed to just building one tuple argument as in `multigrad`) is logic that best fits in core.py.

Hmm... I'm having second thoughts about this one... users can just rewrite their functions to take a dict arg and then manually unpack it.