### PR TITLE
Add fallback when function missing __name__ attribute

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -62,10 +62,12 @@ def backward_pass(start_node, end_node, tape):
 
 def attach_name_and_doc(fun, argnum, opname):
     namestr = "{op}_{fun}_wrt_argnum_{argnum}".format(
-        op=opname.lower(), fun=fun.__name__, argnum=argnum)
+        op=opname.lower(), fun=getattr(fun, '__name__', '[unknown name]'),
+        argnum=argnum)
     docstr = "{op} of function {fun} with respect to argument number {argnum}. " \
         "Has the same arguments as {fun} but the return value has type of" \
-        "argument {argnum}".format(op=opname, fun=fun.__name__, argnum=argnum)
+        "argument {argnum}".format(op=opname, fun=getattr(fun, '__name__',
+        '[unknown name]'), argnum=argnum)
 
     def wrap(gradfun):
         try:


### PR DESCRIPTION
Some callables do not have a `__name__` attribute, for example those returned by functools.partial (see [here](http://stackoverflow.com/questions/33576932/do-all-callables-have-name)). Using `getattr(fun, '__name__', '[unknown name]')` instead of just `fun.__name__` prevents an `AttributeError` being thrown when attaching  `__name__` and `__doc__` in this case.