### PR TITLE
matmul speed up to use BLAS in 2D 2D matmul

### DIFF
--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -344,7 +344,7 @@ anp.dot.defgrads(make_grad_dot, [0, 1])
 def make_grad_matmul(argnum, ans, A, B):
     if anp.ndim(A) == 0 or anp.ndim(B) == 0:
         raise ValueError("Scalar operands are not allowed, use '*' instead")
-    elif anp.ndim(A) == 1 or anp.ndim(B) == 1:
+    elif anp.ndim(A) == 1 or anp.ndim(B) == 1 or (anp.ndim(A) == 2 and anp.ndim(B) == 2):
         axes = ([A.ndim - 1], [max(0, B.ndim - 2)])
         return make_grad_tensordot(argnum, ans, A, B, axes=axes)
     else:


### PR DESCRIPTION
This pull request makes 2D 2D ```matmul``` 12 times faster by this benchmark.
https://gist.github.com/yukoba/719acfc489018b189840a0b1d9904d83

#### Reason

The current NumPy implementation of ```matmul``` and ```tensordot``` are
- without broadcasting: Use BLAS and fast.
- with broadcasting: Do not use BLAS and slow.

```einsum``` is
- Always do not use BLAS and slow.

My original Autograd 2D 2D ```matmul``` uses ```einsum```.
But I changed it to use none broadcasting ```tensordot```.
