### PR TITLE
Examples Python 3.x support

### DIFF
--- a/examples/bayesian_neural_net.py
+++ b/examples/bayesian_neural_net.py
@@ -13,7 +13,7 @@ from optimizers import adam
 def make_nn_funs(layer_sizes, L2_reg, noise_variance, nonlinearity=np.tanh):
     """These functions implement a standard multi-layer perceptron,
     vectorized over both training examples and weight samples."""
-    shapes = zip(layer_sizes[:-1], layer_sizes[1:])
+    shapes = list(zip(layer_sizes[:-1], layer_sizes[1:]))
     num_weights = sum((m+1)*n for m, n in shapes)
 
     def unpack_layers(weights):

--- a/examples/bayesian_optimization.py
+++ b/examples/bayesian_optimization.py
@@ -50,9 +50,9 @@ def bayesian_optimize(func, domain_min, domain_max, num_iters=20, callback=None)
         def optimize_point(init_point):
             print('.', end='')
             result = minimize(grad_obj, x0=init_point, jac=True, method='L-BFGS-B',
-                              options={'maxiter': 10}, bounds=zip(domain_min, domain_max))
+                              options={'maxiter': 10}, bounds=list(zip(domain_min, domain_max)))
             return result.x, acquisition_function(result.x)
-        optimzed_points, optimized_values = zip(*map(optimize_point, init_points))
+        optimzed_points, optimized_values = list(zip(*list(map(optimize_point, init_points))))
         print()
         best_ix = np.argmax(optimized_values)
         return np.atleast_2d(optimzed_points[best_ix])

--- a/examples/convnet.py
+++ b/examples/convnet.py
@@ -8,6 +8,7 @@ import autograd.numpy.random as npr
 import autograd.scipy.signal
 from autograd import grad
 from builtins import range
+import data_mnist
 
 convolve = autograd.scipy.signal.convolve
 
@@ -161,13 +162,10 @@ if __name__ == '__main__':
 
     # Load and process MNIST data (borrowing from Kayak)
     print("Loading training data...")
-    import imp, urllib
+    import imp
     add_color_channel = lambda x : x.reshape((x.shape[0], 1, x.shape[1], x.shape[2]))
     one_hot = lambda x, K : np.array(x[:,None] == np.arange(K)[None, :], dtype=int)
-    source, _ = urllib.urlretrieve(
-        'https://raw.githubusercontent.com/HIPS/Kayak/master/examples/data.py')
-    data = imp.load_source('data', source).mnist()
-    train_images, train_labels, test_images, test_labels = data
+    train_images, train_labels, test_images, test_labels = data_mnist.mnist()
     train_images = add_color_channel(train_images) / 255.0
     test_images  = add_color_channel(test_images)  / 255.0
     train_labels = one_hot(train_labels, 10)

--- a/examples/data.py
+++ b/examples/data.py
@@ -1,15 +1,13 @@
 from __future__ import absolute_import
 import autograd.numpy as np
 import autograd.numpy.random as npr
-import imp, urllib
+import imp
+import data_mnist
 
 def load_mnist():
     partial_flatten = lambda x : np.reshape(x, (x.shape[0], np.prod(x.shape[1:])))
     one_hot = lambda x, k: np.array(x[:,None] == np.arange(k)[None, :], dtype=int)
-    source, _ = urllib.urlretrieve(
-        'https://raw.githubusercontent.com/HIPS/Kayak/master/examples/data.py')
-    data = imp.load_source('data', source).mnist()
-    train_images, train_labels, test_images, test_labels = data
+    train_images, train_labels, test_images, test_labels = data_mnist.mnist()
     train_images = partial_flatten(train_images) / 255.0
     test_images  = partial_flatten(test_images)  / 255.0
     train_labels = one_hot(train_labels, 10)

--- a/examples/data_mnist.py
+++ b/examples/data_mnist.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from future.standard_library import install_aliases
+install_aliases()
+
+import os
+import gzip
+import struct
+import array
+import numpy as np
+from urllib.request import urlretrieve
+
+def download(url, filename):
+    if not os.path.exists('data'):
+        os.makedirs('data')
+    out_file = os.path.join('data', filename)
+    if not os.path.isfile(out_file):
+        urlretrieve(url, out_file)
+
+def mnist():
+    base_url = 'http://yann.lecun.com/exdb/mnist/'
+
+    def parse_labels(filename):
+        with gzip.open(filename, 'rb') as fh:
+            magic, num_data = struct.unpack(">II", fh.read(8))
+            return np.array(array.array("B", fh.read()), dtype=np.uint8)
+
+    def parse_images(filename):
+        with gzip.open(filename, 'rb') as fh:
+            magic, num_data, rows, cols = struct.unpack(">IIII", fh.read(16))
+            return np.array(array.array("B", fh.read()), dtype=np.uint8).reshape(num_data, rows, cols)
+
+    for filename in ['train-images-idx3-ubyte.gz',
+                     'train-labels-idx1-ubyte.gz',
+                     't10k-images-idx3-ubyte.gz',
+                     't10k-labels-idx1-ubyte.gz']:
+        download(base_url + filename, filename)
+
+    train_images = parse_images('data/train-images-idx3-ubyte.gz')
+    train_labels = parse_labels('data/train-labels-idx1-ubyte.gz')
+    test_images  = parse_images('data/t10k-images-idx3-ubyte.gz')
+    test_labels  = parse_labels('data/t10k-labels-idx1-ubyte.gz')
+
+    return train_images, train_labels, test_images, test_labels

--- a/examples/hmm_em.py
+++ b/examples/hmm_em.py
@@ -10,10 +10,10 @@ import string
 
 def EM(init_params, data, callback=None):
     def EM_update(params):
-        natural_params = map(np.log, params)
+        natural_params = list(map(np.log, params))
         loglike, E_stats = vgrad(log_partition_function)(natural_params, data)  # E step
         if callback: callback(loglike, params)
-        return map(normalize, E_stats)                                          # M step
+        return list(map(normalize, E_stats))                                    # M step
 
     def fixed_point(f, x0):
         x1 = f(x0)
@@ -56,7 +56,7 @@ def initialize_hmm_parameters(num_states, num_outputs):
 
 def build_dataset(filename, max_lines=-1):
     """Loads a text file, and turns each line into an encoded sequence."""
-    encodings = dict(map(reversed, enumerate(string.printable)))
+    encodings = dict(list(map(reversed, enumerate(string.printable))))
     digitize = lambda char: encodings[char] if char in encodings else len(encodings)
     encode_line = lambda line: np.array(list(map(digitize, line)))
     nonblank_line = lambda line: len(line) > 2
@@ -64,7 +64,7 @@ def build_dataset(filename, max_lines=-1):
     with open(filename) as f:
         lines = f.readlines()
 
-    encoded_lines = map(encode_line, filter(nonblank_line, lines)[:max_lines])
+    encoded_lines = list(map(encode_line, list(filter(nonblank_line, lines))[:max_lines]))
     num_outputs = len(encodings) + 1
 
     return encoded_lines, num_outputs

--- a/examples/ica.py
+++ b/examples/ica.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
 
     rs = npr.RandomState(0)
     true_weights = np.zeros((observed_dimension, latent_dimension))
-    for i in xrange(latent_dimension):
+    for i in range(latent_dimension):
         true_weights[:,i] = np.sin(np.linspace(0,4 + i*3.2, observed_dimension))
 
     true_latents, data = sample(true_weights, n_samples, true_noise_var, rs)

--- a/examples/neural_net_regression.py
+++ b/examples/neural_net_regression.py
@@ -12,7 +12,7 @@ from optimizers import adam
 
 def make_nn_funs(layer_sizes, weight_scale=10.0, noise_scale=0.1, nonlinearity=np.tanh):
     """These functions implement a standard multi-layer perceptron."""
-    shapes = zip(layer_sizes[:-1], layer_sizes[1:])
+    shapes = list(zip(layer_sizes[:-1], layer_sizes[1:]))
     num_weights = sum((m+1)*n for m, n in shapes)
 
     def unpack_layers(weights):


### PR DESCRIPTION
I modified examples to support Python 3.x.
This fixes https://github.com/HIPS/autograd/issues/121 .

I also copied https://raw.githubusercontent.com/HIPS/Kayak/master/examples/data.py 
to examples/data_mnist.py and modified to support Python 3.x.

To run examples/bayesian_optimization.py on Python 3.x, you need another modification,
and I sent it in another pull request https://github.com/HIPS/autograd/pull/124 .

