### PR TITLE
Add allow_singular and default values to multivariate_normal

### DIFF
--- a/autograd/scipy/stats/multivariate_normal.py
+++ b/autograd/scipy/stats/multivariate_normal.py
@@ -39,14 +39,14 @@ def covgrad(x, mean, cov):
     solved = np.linalg.solve(cov, (x - mean).T).T
     return lower_half(np.linalg.inv(cov) - generalized_outer_product(solved))
 
-logpdf.defgrad(lambda ans, x, mean, cov: unbroadcast(ans, x,    lambda g: -np.expand_dims(g, 1) * np.linalg.solve(cov, (x - mean).T).T), argnum=0)
-logpdf.defgrad(lambda ans, x, mean, cov: unbroadcast(ans, mean, lambda g:  np.expand_dims(g, 1) * np.linalg.solve(cov, (x - mean).T).T), argnum=1)
-logpdf.defgrad(lambda ans, x, mean, cov: unbroadcast(ans, cov,  lambda g: -np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov)), argnum=2)
+logpdf.defgrad(lambda ans, x, mean=None, cov=1, allow_singular=False: unbroadcast(ans, x,    lambda g: -np.expand_dims(g, 1) * np.linalg.solve(cov, (x - mean).T).T), argnum=0)
+logpdf.defgrad(lambda ans, x, mean=None, cov=1, allow_singular=False: unbroadcast(ans, mean, lambda g:  np.expand_dims(g, 1) * np.linalg.solve(cov, (x - mean).T).T), argnum=1)
+logpdf.defgrad(lambda ans, x, mean=None, cov=1, allow_singular=False: unbroadcast(ans, cov,  lambda g: -np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov)), argnum=2)
 
 # Same as log pdf, but multiplied by the pdf (ans).
-pdf.defgrad(lambda ans, x, mean, cov: unbroadcast(ans, x,    lambda g: -g * ans * np.linalg.solve(cov, x - mean)), argnum=0)
-pdf.defgrad(lambda ans, x, mean, cov: unbroadcast(ans, mean, lambda g:  g * ans * np.linalg.solve(cov, x - mean)), argnum=1)
-pdf.defgrad(lambda ans, x, mean, cov: unbroadcast(ans, cov,  lambda g: -g * ans * covgrad(x, mean, cov)),          argnum=2)
+pdf.defgrad(lambda ans, x, mean=None, cov=1, allow_singular=False: unbroadcast(ans, x,    lambda g: -g * ans * np.linalg.solve(cov, x - mean)), argnum=0)
+pdf.defgrad(lambda ans, x, mean=None, cov=1, allow_singular=False: unbroadcast(ans, mean, lambda g:  g * ans * np.linalg.solve(cov, x - mean)), argnum=1)
+pdf.defgrad(lambda ans, x, mean=None, cov=1, allow_singular=False: unbroadcast(ans, cov,  lambda g: -g * ans * covgrad(x, mean, cov)),          argnum=2)
 
 entropy.defgrad_is_zero(argnums=(0,))
 entropy.defgrad(lambda ans, mean, cov: unbroadcast(ans, cov, lambda g:  0.5 * g * np.linalg.inv(cov).T), argnum=1)

--- a/examples/gaussian_process.py
+++ b/examples/gaussian_process.py
@@ -35,7 +35,7 @@ def make_gp_funs(cov_func, num_cov_params):
         mean, cov_params, noise_scale = unpack_kernel_params(params)
         cov_y_y = cov_func(cov_params, x, x) + noise_scale * np.eye(len(y))
         prior_mean = mean * np.ones(len(y))
-        return mvn.logpdf(y, prior_mean, cov_y_y)
+        return mvn.logpdf(y, prior_mean, cov_y_y, True)
 
     return num_cov_params + 2, predict, log_marginal_likelihood
 


### PR DESCRIPTION
I added allow_singular and default values to multivariate_normal.
This is necessary to run examples/bayesian_optimization.py on Python 3.x.