### PR TITLE
Fix typo in attach_name_and_doc

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -66,7 +66,7 @@ def attach_name_and_doc(fun, argnum, opname):
         argnum=argnum)
     docstr = "{op} of function {fun} with respect to argument number {argnum}. " \
         "Has the same arguments as {fun} but the return value has type of " \
-        "argument {argnum}".format(op=opname, fun=getattr(fun, '__name__',
+        "argument {argnum}.".format(op=opname, fun=getattr(fun, '__name__',
         '[unknown name]'), argnum=argnum)
 
     def wrap(gradfun):

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -65,7 +65,7 @@ def attach_name_and_doc(fun, argnum, opname):
         op=opname.lower(), fun=getattr(fun, '__name__', '[unknown name]'),
         argnum=argnum)
     docstr = "{op} of function {fun} with respect to argument number {argnum}. " \
-        "Has the same arguments as {fun} but the return value has type of" \
+        "Has the same arguments as {fun} but the return value has type of " \
         "argument {argnum}".format(op=opname, fun=getattr(fun, '__name__',
         '[unknown name]'), argnum=argnum)
 


### PR DESCRIPTION
There should be a space here. I thought I might have introduced this typo but looks like it was there already.