### PR TITLE
Remove unnecessary import imp

### DIFF
--- a/examples/convnet.py
+++ b/examples/convnet.py
@@ -160,9 +160,8 @@ if __name__ == '__main__':
     batch_size = 256
     num_epochs = 50
 
-    # Load and process MNIST data (borrowing from Kayak)
+    # Load and process MNIST data
     print("Loading training data...")
-    import imp
     add_color_channel = lambda x : x.reshape((x.shape[0], 1, x.shape[1], x.shape[2]))
     one_hot = lambda x, K : np.array(x[:,None] == np.arange(K)[None, :], dtype=int)
     train_images, train_labels, test_images, test_labels = data_mnist.mnist()

--- a/examples/data.py
+++ b/examples/data.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import autograd.numpy as np
 import autograd.numpy.random as npr
-import imp
 import data_mnist
 
 def load_mnist():


### PR DESCRIPTION
Sorry, I forget to remove ```import imp``` from examples.
This is unnecessary because I created examples/data_mnist.py.