### PR TITLE
Use a[idx] += b instead of numpy.add.at(a, idx, b)

### DIFF
--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -123,7 +123,8 @@ def primitive_sum_arrays(*arrays):
     new_array = type(new_array_node(arrays[0], [])).zeros_like(arrays[0]) # TODO: simplify this
     for array in arrays:
         if isinstance(array, SparseArray):
-            np.add.at(new_array, array.idx, array.val)
+            new_array[array.idx] += array.val
+            #np.add.at(new_array, array.idx, array.val)
         else:
             new_array += array
     return new_array


### PR DESCRIPTION
numpy.add.at is slow (https://github.com/numpy/numpy/issues/5922); this change uses += instead, as long as we can be sure (?) that no element is indexed more than once. This speeds up my toy example by about 40%. 