### PR TITLE
Implement svd gradient

### DIFF
--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -8,7 +8,7 @@ from autograd import grad
 from builtins import range
 from functools import partial
 
-npr.seed(0)
+npr.seed(1)
 
 def check_symmetric_matrix_grads(fun, *args):
     def symmetrize(A):

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -264,3 +264,67 @@ def test_svd_wide_2d():
     n = 5
     mat = npr.randn(m, n)
     check_grads(fun, mat)
+
+def test_svd_wide_3d():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return to_scalar(u) + to_scalar(s) + to_scalar(v)
+
+    k = 4
+    m = 3
+    n = 5
+
+    mat = npr.randn(k, m, n)
+    check_grads(fun, mat)
+
+def test_svd_square_2d():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return to_scalar(u) + to_scalar(s) + to_scalar(v)
+    m = 4
+    n = 4
+    mat = npr.randn(m, n)
+    check_grads(fun, mat)
+
+def test_svd_square_3d():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return to_scalar(u) + to_scalar(s) + to_scalar(v)
+
+    k = 3
+    m = 4
+    n = 4
+
+    mat = npr.randn(k, m, n)
+    check_grads(fun, mat)
+
+def test_svd_tall_2d():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return to_scalar(u) + to_scalar(s) + to_scalar(v)
+    m = 5
+    n = 3
+    mat = npr.randn(m, n)
+    check_grads(fun, mat)
+
+def test_svd_tall_3d():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return to_scalar(u) + to_scalar(s) + to_scalar(v)
+
+    k = 4
+    m = 5
+    n = 3
+
+    mat = npr.randn(k, m, n)
+    check_grads(fun, mat)
+
+def test_svd_only_s_2d():
+    def fun(x):
+        s = np.linalg.svd(x, full_matrices=False, compute_uv=False)
+        return to_scalar(s)
+
+    m = 5
+    n = 3
+    mat = npr.randn(m, n)
+    check_grads(fun, mat)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -255,3 +255,12 @@ def test_solve_triangular_arg2_2d():
         def fun(B):
             return to_scalar(spla.solve_triangular(A, B, trans=trans, lower=lower))
         yield check_grads, fun, npr.randn(D, D-1)
+
+def test_svd_wide_2d():
+    def fun(x):
+        u, s, v = np.linalg.svd(x)
+        return to_scalar(u) + to_scalar(s) + to_scalar(v)
+    m = 3
+    n = 5
+    mat = npr.randn(m, n)
+    check_grads(fun, mat)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -328,3 +328,15 @@ def test_svd_only_s_2d():
     n = 3
     mat = npr.randn(m, n)
     check_grads(fun, mat)
+
+def test_svd_only_s_3d():
+    def fun(x):
+        s = np.linalg.svd(x, full_matrices=False, compute_uv=False)
+        return to_scalar(s)
+
+    k = 4
+    m = 5
+    n = 3
+
+    mat = npr.randn(k, m, n)
+    check_grads(fun, mat)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -8,7 +8,7 @@ from autograd import grad
 from builtins import range
 from functools import partial
 
-npr.seed(1)
+npr.seed(0)
 
 def check_symmetric_matrix_grads(fun, *args):
     def symmetrize(A):
@@ -258,7 +258,7 @@ def test_solve_triangular_arg2_2d():
 
 def test_svd_wide_2d():
     def fun(x):
-        u, s, v = np.linalg.svd(x)
+        u, s, v = np.linalg.svd(x, full_matrices=False)
         return to_scalar(u) + to_scalar(s) + to_scalar(v)
     m = 3
     n = 5


### PR DESCRIPTION
See [here](https://j-towns.github.io/papers/svd-derivative.pdf) for a fairly complete derivation. Note that the derivation in the [Mike Giles paper](http://arxiv.org/abs/1602.07527) is missing the terms which I denote dK and is therefore not correct. A few points:

* The svd is not quite unique (multiplying a column of U and the corresponding column of V by -1 still gives a valid svd), and therefore its Jacobian is not unique either, and what the user gets is the Jacobian of the branch of the svd that they are on (hope that makes sense). I believe this is the same for `eigh` since multiplying one of the eigenvectors by -1 still gives a correct eigenvector.
* If `full_matrices=True`, then I think this non-uniqueness gets a lot worse, and I haven't yet tried to work out if it's still possible to get a sensible gradient in this case.
* I haven't put time into making this fast or memory efficient, just focussed on getting it working, so I guess there is still more to do there.