### PR TITLE
Add numpy.lib.pad, numpy.copy and numpy.compat

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -254,6 +254,24 @@ class CalculationTape(list):
     def __hash__(self):
         return id(self)
 
+class BoolNode(Node):
+    __slots__ = []
+    @staticmethod
+    def zeros_like(value):
+        return False
+    @staticmethod
+    def cast(value, example):
+        return cast(value, cast_to_bool)
+
+class IntNode(Node):
+    __slots__ = []
+    @staticmethod
+    def zeros_like(value):
+        return 0
+    @staticmethod
+    def cast(value, example):
+        return cast(value, cast_to_int)
+
 class FloatNode(Node):
     __slots__ = []
     @staticmethod
@@ -263,7 +281,19 @@ class FloatNode(Node):
     def cast(value, example):
         return cast(value, cast_to_float)
 
+Node.type_mappings[bool] = BoolNode
+Node.type_mappings[int] = IntNode
 Node.type_mappings[float] = FloatNode
+
+def cast_to_bool(x):
+    if np.iscomplexobj(x):
+        x = np.real(x)
+    return bool(x)
+
+def cast_to_int(x):
+    if np.iscomplexobj(x):
+        x = np.real(x)
+    return int(x)
 
 def cast_to_float(x):
     if np.iscomplexobj(x):

--- a/autograd/numpy/__init__.py
+++ b/autograd/numpy/__init__.py
@@ -12,3 +12,4 @@ from .numpy_wrapper import *
 from . import linalg
 from . import fft
 from . import random
+from . import compat

--- a/autograd/numpy/__init__.py
+++ b/autograd/numpy/__init__.py
@@ -13,3 +13,4 @@ from . import linalg
 from . import fft
 from . import random
 from . import compat
+from . import lib

--- a/autograd/numpy/compat/__init__.py
+++ b/autograd/numpy/compat/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from numpy.compat import *

--- a/autograd/numpy/lib/__init__.py
+++ b/autograd/numpy/lib/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .arraypad import *

--- a/autograd/numpy/lib/arraypad.py
+++ b/autograd/numpy/lib/arraypad.py
@@ -1,0 +1,7 @@
+import imp
+
+_, pathname, _ = imp.find_module("numpy")
+with open(pathname + "/lib/arraypad.py", "rt") as fp:
+    src = fp.read()
+src = src.replace("import numpy as np", "from autograd.numpy import numpy_wrapper as np")
+exec(src, globals(), locals())

--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -36,6 +36,9 @@ class ArrayNode(Node):
     def __len__(self):
         return len(self.value)
 
+    def copy(self, order='C'):
+        return anp.array(self, order=order)
+
     @staticmethod
     def zeros_like(value):
         return anp.zeros(value.shape)

--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import numpy as np
 
-from autograd.core import (Node, FloatNode, primitive, cast,
+from autograd.core import (Node, BoolNode, IntNode, FloatNode, primitive, cast,
                            differentiable_ops, nondifferentiable_ops, getval)
 from . import numpy_wrapper as anp
 from .use_gpu_numpy import use_gpu_numpy
@@ -83,6 +83,9 @@ class ArrayNode(Node):
     def __le__(self, other): return anp.less_equal(self, other)
     def __abs__(self): return anp.abs(self)
 
+    def astype(self, dtype, order='K', casting='unsafe', subok=True, copy=True):
+        return anp.astype(self, dtype, order, casting, subok, copy)
+
 def new_array_node(value, tapes):
     try:
         return array_dtype_mappings[value.dtype](value, tapes)
@@ -91,6 +94,13 @@ def new_array_node(value, tapes):
 Node.type_mappings[anp.ndarray] = new_array_node
 
 array_dtype_mappings = {}
+for bool_type in [anp.bool8]:
+    array_dtype_mappings[anp.dtype(bool_type)] = ArrayNode
+    Node.type_mappings[bool_type] = BoolNode
+for int_type in [anp.int8, anp.int16, anp.int32, anp.int64,
+                 anp.uint8, anp.uint16, anp.uint32, anp.uint64]:
+    array_dtype_mappings[anp.dtype(int_type)] = ArrayNode
+    Node.type_mappings[int_type] = IntNode
 for float_type in [anp.float64, anp.float32, anp.float16]:
     array_dtype_mappings[anp.dtype(float_type)] = ArrayNode
     Node.type_mappings[float_type] = FloatNode

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -181,6 +181,19 @@ anp.frexp.defgrad(lambda ans, x: lambda g : g[0] * 2.0 ** -ans[1])
 
 # ----- Trickier grads -----
 
+@primitive
+def astype(ary, dtype, order='K', casting='unsafe', subok=True, copy=True):
+    return ary.astype(dtype, order, casting, subok, copy)
+def make_grad_astype(ans, ary, dtype, order='K', casting='unsafe', subok=True, copy=True):
+    if dtype in (anp.int8, anp.int16, anp.int32, anp.int64,
+                 anp.uint8, anp.uint16, anp.uint32, anp.uint64,
+                 anp.bool8):
+        return lambda g: anp.zeros(g.shape)
+    else:
+        return I
+anp.astype = astype
+anp.astype.defgrad(make_grad_astype)
+
 def make_grad_diff(ans, a, n=1, axis=-1):
     nd = len(a.shape)
     sl1 = [slice(None)]*nd

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import types
 from .use_gpu_numpy import use_gpu_numpy
 from future.utils import iteritems
+from . import compat
 
 
 if use_gpu_numpy():

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -78,6 +78,9 @@ def wrap_if_nodes_inside(raw_array, slow_op_name=None):
     else:
         return raw_array
 
+def copy(a, order='K'):
+    return array(a, order=order)
+
 @primitive
 def array_from_args(*args):
     return np.array(args)

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -15,15 +15,24 @@ from autograd.container_types import ListNode, TupleNode, make_tuple
 if use_gpu_numpy():
     garray_obj = np.garray
     array_types = (np.ndarray, garray_obj)
-    EPS, RTOL, ATOL = 1e-4, 1e-2, 1e-2
+    initial_eps_rtol_atol = 1e-4, 1e-2, 1e-2
 else:
     garray_obj = ()
     array_types = (np.ndarray,)
-    EPS, RTOL, ATOL = 1e-3, 1e-3, 1e-3
+    initial_eps_rtol_atol = 1e-4, 1e-4, 1e-6
+EPS, RTOL, ATOL = initial_eps_rtol_atol
+
+def set_eps_rtol_atol(eps, rtol, atol):
+    global EPS, RTOL, ATOL
+    EPS, RTOL, ATOL = eps, rtol, atol
+
+def reset_eps_rtol_atol():
+    global EPS, RTOL, ATOL
+    EPS, RTOL, ATOL = initial_eps_rtol_atol
 
 def nd(f, *args):
     unary_f = lambda x : f(*x)
-    return unary_nd(unary_f, args)
+    return unary_nd(unary_f, args, EPS)
 
 def unary_nd(f, x, eps=EPS):
     if isinstance(x, array_types):
@@ -34,15 +43,15 @@ def unary_nd(f, x, eps=EPS):
         else:
             nd_grad = np.zeros(x.shape)
         for dims in it.product(*list(map(range, x.shape))):
-            nd_grad[dims] = unary_nd(indexed_function(f, x, dims), x[dims])
+            nd_grad[dims] = unary_nd(indexed_function(f, x, dims), x[dims], eps)
         return nd_grad
     elif isinstance(x, tuple):
-        return tuple([unary_nd(indexed_function(f, tuple(x), i), x[i])
+        return tuple([unary_nd(indexed_function(f, tuple(x), i), x[i], eps)
                       for i in range(len(x))])
     elif isinstance(x, dict):
-        return {k : unary_nd(indexed_function(f, x, k), v) for k, v in iteritems(x)}
+        return {k : unary_nd(indexed_function(f, x, k), v, eps) for k, v in iteritems(x)}
     elif isinstance(x, list):
-        return [unary_nd(indexed_function(f, x, i), v) for i, v in enumerate(x)]
+        return [unary_nd(indexed_function(f, x, i), v, eps) for i, v in enumerate(x)]
     elif np.iscomplexobj(x):
         result = (f(x +    eps/2) - f(x -    eps/2)) / eps \
             - 1j*(f(x + 1j*eps/2) - f(x - 1j*eps/2)) / eps
@@ -66,10 +75,10 @@ def check_equivalent(A, B, rtol=RTOL, atol=ATOL):
     assert base_class(type(A)) is base_class(type(B)),\
         "Types are: {0} and {1}".format(type(A), type(B))
     if isinstance(A, (tuple, list)):
-        for a, b in zip(A, B): check_equivalent(a, b)
+        for a, b in zip(A, B): check_equivalent(a, b, rtol, atol)
     elif isinstance(A, dict):
         assert len(A) == len(B)
-        for k in A: check_equivalent(A[k], B[k])
+        for k in A: check_equivalent(A[k], B[k], rtol, atol)
     else:
         if isinstance(A, np.ndarray):
             assert A.shape == B.shape, "Shapes are analytic: {0} and numeric: {1}".format(
@@ -85,7 +94,7 @@ def check_grads(fun, *args):
         raise Exception("No args given")
     exact = tuple([grad(fun, i)(*args) for i in range(len(args))])
     numeric = nd(fun, *args)
-    check_equivalent(exact, numeric)
+    check_equivalent(exact, numeric, RTOL, ATOL)
 
 def to_scalar(x):
     if isinstance(x, list)  or isinstance(x, ListNode) or \

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -19,7 +19,7 @@ if use_gpu_numpy():
 else:
     garray_obj = ()
     array_types = (np.ndarray,)
-    EPS, RTOL, ATOL = 1e-4, 1e-4, 1e-6
+    EPS, RTOL, ATOL = 1e-3, 1e-3, 1e-3
 
 def nd(f, *args):
     unary_f = lambda x : f(*x)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description='Efficiently computes derivatives of numpy code.',
     author='Dougal Maclaurin and David Duvenaud and Matthew Johnson',
     author_email="maclaurin@physics.harvard.edu, duvenaud@cs.toronto.edu, mattjj@csail.mit.edu",
-    packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats'],
+    packages=['autograd', 'autograd.numpy', 'autograd.numpy.compat', 'autograd.scipy', 'autograd.scipy.stats'],
     install_requires=['numpy>=1.10', 'scipy>=0.17', 'future>=0.15.2'],
     setup_requires=['numpy>=1.10', 'scipy>=0.17'],
     keywords=['Automatic differentiation', 'backpropagation', 'gradients',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description='Efficiently computes derivatives of numpy code.',
     author='Dougal Maclaurin and David Duvenaud and Matthew Johnson',
     author_email="maclaurin@physics.harvard.edu, duvenaud@cs.toronto.edu, mattjj@csail.mit.edu",
-    packages=['autograd', 'autograd.numpy', 'autograd.numpy.compat', 'autograd.scipy', 'autograd.scipy.stats'],
+    packages=['autograd', 'autograd.numpy', 'autograd.numpy.compat', 'autograd.numpy.lib', 'autograd.scipy', 'autograd.scipy.stats'],
     install_requires=['numpy>=1.10', 'scipy>=0.17', 'future>=0.15.2'],
     setup_requires=['numpy>=1.10', 'scipy>=0.17'],
     keywords=['Automatic differentiation', 'backpropagation', 'gradients',

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -15,7 +15,7 @@ def test_nograd():
     fun = lambda x: np.allclose(x, (x*3.0)/3.0)
     try:
         grad(fun)(np.array([1., 2., 3.]))
-    except TypeError:
+    except NotImplementedError:
         pass
     else:
         raise Exception('Expected non-differentiability exception')

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -868,7 +868,9 @@ def test_maximum_equal_values_2d():
     check_grads(d_fun, 2.0)
 
 def test_astype():
+    set_eps_rtol_atol(1e-3, 1e-3, 1e-3)
     for dtype in (np.bool8, np.int32, np.int64, np.float32, np.float64):
         def fun(x): return to_scalar(x.astype(dtype))
         mat = npr.randn(10, 11)
         check_grads(fun, mat)
+    reset_eps_rtol_atol()

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import warnings
 
+import numpy as onp
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd.util import *
@@ -348,6 +349,16 @@ def test_concatenate_axis_1_unnamed():
     d_fun = lambda x : to_scalar(grad(fun)(x))
     check_grads(fun, A)
     check_grads(d_fun, A)
+
+def test_pad():
+    for mode in ("constant", "edge", "linear_ramp", "maximum", "mean", "minimum", "reflect", "symmetric", "wrap"):
+        def fun(x): return to_scalar(np.lib.pad(x, ((1, 2), (2, 0)), mode))
+        d_fun = lambda x : to_scalar(grad(fun)(x))
+        mat = npr.randn(4, 3)
+        if not np.allclose(np.lib.pad(mat, ((1, 2), (2, 0)), mode), onp.lib.pad(mat, ((1, 2), (2, 0)), mode)):
+            raise ValueError()
+        check_grads(fun, mat)
+        check_grads(d_fun, mat)
 
 def test_trace():
     def fun(x): return np.trace(x, offset=offset)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -868,9 +868,13 @@ def test_maximum_equal_values_2d():
     check_grads(d_fun, 2.0)
 
 def test_astype():
-    set_eps_rtol_atol(1e-3, 1e-3, 1e-3)
     for dtype in (np.bool8, np.int32, np.int64, np.float32, np.float64):
+        if dtype == np.float32:
+            set_eps_rtol_atol(1e-3, 1e-3, 1e-3)
+
         def fun(x): return to_scalar(x.astype(dtype))
         mat = npr.randn(10, 11)
         check_grads(fun, mat)
-    reset_eps_rtol_atol()
+
+        if dtype == np.float32:
+            reset_eps_rtol_atol()

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -866,3 +866,9 @@ def test_maximum_equal_values_2d():
     check_grads(d_fun, -1.0)
     check_grads(fun, 2.0)
     check_grads(d_fun, 2.0)
+
+def test_astype():
+    for dtype in (np.bool8, np.int32, np.int64, np.float32, np.float64):
+        def fun(x): return to_scalar(x.astype(dtype))
+        mat = npr.randn(10, 11)
+        check_grads(fun, mat)


### PR DESCRIPTION
I added `numpy.lib.pad()`.
I also added `numpy.copy()` and `numpy.compat` because they are needed for `pad()`.

I copied and modified arraypad.py from NumPy.
Is it all right to do such a thing?
## What I modified arraypad.py
### Modify 1

I changed from `import numpy as np` to `from autograd.numpy import numpy_wrapper as np`.
### Modify 2

Because of bug https://github.com/HIPS/autograd/issues/138 , I changed like this.

``` diff
-    max_chunk = arr[max_slice].max(axis=axis).reshape(pad_singleton)
+    max_chunk = arr1[max_slice].max(axis=axis).reshape(pad_singleton)
```

and

``` diff
-            newmat = _prepend_max(newmat, pad_before, chunk_before, axis)
-            newmat = _append_max(newmat, pad_after, chunk_after, axis)
+            newmat2 = _prepend_max(newmat, pad_before, chunk_before, axis)
+            newmat = _append_max(newmat2, newmat, pad_after, chunk_after, axis)
```

This should be reverted if https://github.com/HIPS/autograd/issues/138 is fixed.
### Modify 3

Removed `astype(arr.dtype)`. astype is not supported in AutoGrad.
### Modify 4

Because `median` is not implemented in AutoGrad https://github.com/HIPS/autograd/issues/139 , I added this.

``` diff
+    if mode == "median":
+        raise ValueError("%s is not implemented" % mode)
```
## Diff of arraypad.py

``` diff
--- arraypad-orig.py    2016-08-14 03:49:55.057816000 +0900
+++ arraypad.py 2016-08-14 13:45:09.377455600 +0900
@@ -3,9 +3,14 @@
 of an n-dimensional array.

 """
+###############################################################################
+# This code is copied and modified from NumPy 1.11.1
+# https://github.com/numpy/numpy/blob/v1.11.1/numpy/lib/arraypad.py
+###############################################################################
+
 from __future__ import division, absolute_import, print_function

-import numpy as np
+from autograd.numpy import numpy_wrapper as np


 __all__ = ['pad']
@@ -261,7 +266,7 @@
     _round_ifneeded(ramp_arr, arr.dtype)

     # Ramp values will most likely be float, cast them to the same type as arr
-    return np.concatenate((ramp_arr.astype(arr.dtype), arr), axis=axis)
+    return np.concatenate((ramp_arr, arr), axis=axis)


 def _append_ramp(arr, pad_amt, end, axis=-1):
@@ -316,7 +321,7 @@
     _round_ifneeded(ramp_arr, arr.dtype)

     # Ramp values will most likely be float, cast them to the same type as arr
-    return np.concatenate((arr, ramp_arr.astype(arr.dtype)), axis=axis)
+    return np.concatenate((arr, ramp_arr), axis=axis)


 def _prepend_max(arr, pad_amt, num, axis=-1):
@@ -371,7 +376,7 @@
                           axis=axis)


-def _append_max(arr, pad_amt, num, axis=-1):
+def _append_max(arr, arr1, pad_amt, num, axis=-1):
     """
     Pad one `axis` of `arr` with the maximum of the last `num` elements.

@@ -420,7 +425,7 @@
                           for (i, x) in enumerate(arr.shape))

     # Extract slice, calculate max, reshape to add singleton dimension back
-    max_chunk = arr[max_slice].max(axis=axis).reshape(pad_singleton)
+    max_chunk = arr1[max_slice].max(axis=axis).reshape(pad_singleton)

     # Concatenate `arr` with `max_chunk`, extended along `axis` by `pad_amt`
     return np.concatenate((arr, max_chunk.repeat(pad_amt, axis=axis)),
@@ -475,11 +480,11 @@
     _round_ifneeded(mean_chunk, arr.dtype)

     # Concatenate `arr` with `mean_chunk`, extended along `axis` by `pad_amt`
-    return np.concatenate((mean_chunk.repeat(pad_amt, axis).astype(arr.dtype),
+    return np.concatenate((mean_chunk.repeat(pad_amt, axis),
                            arr), axis=axis)


-def _append_mean(arr, pad_amt, num, axis=-1):
+def _append_mean(arr, arr1, pad_amt, num, axis=-1):
     """
     Append `pad_amt` mean values along `axis`.

@@ -528,12 +533,12 @@
                           for (i, x) in enumerate(arr.shape))

     # Extract slice, calculate mean, reshape to add singleton dimension back
-    mean_chunk = arr[mean_slice].mean(axis=axis).reshape(pad_singleton)
+    mean_chunk = arr1[mean_slice].mean(axis=axis).reshape(pad_singleton)
     _round_ifneeded(mean_chunk, arr.dtype)

     # Concatenate `arr` with `mean_chunk`, extended along `axis` by `pad_amt`
     return np.concatenate(
-        (arr, mean_chunk.repeat(pad_amt, axis).astype(arr.dtype)), axis=axis)
+        (arr, mean_chunk.repeat(pad_amt, axis)), axis=axis)


 def _prepend_med(arr, pad_amt, num, axis=-1):
@@ -585,10 +590,10 @@

     # Concatenate `arr` with `med_chunk`, extended along `axis` by `pad_amt`
     return np.concatenate(
-        (med_chunk.repeat(pad_amt, axis).astype(arr.dtype), arr), axis=axis)
+        (med_chunk.repeat(pad_amt, axis), arr), axis=axis)


-def _append_med(arr, pad_amt, num, axis=-1):
+def _append_med(arr, arr1, pad_amt, num, axis=-1):
     """
     Append `pad_amt` median values along `axis`.

@@ -637,12 +642,12 @@
                           for (i, x) in enumerate(arr.shape))

     # Extract slice, calculate median, reshape to add singleton dimension back
-    med_chunk = np.median(arr[med_slice], axis=axis).reshape(pad_singleton)
+    med_chunk = np.median(arr1[med_slice], axis=axis).reshape(pad_singleton)
     _round_ifneeded(med_chunk, arr.dtype)

     # Concatenate `arr` with `med_chunk`, extended along `axis` by `pad_amt`
     return np.concatenate(
-        (arr, med_chunk.repeat(pad_amt, axis).astype(arr.dtype)), axis=axis)
+        (arr, med_chunk.repeat(pad_amt, axis)), axis=axis)


 def _prepend_min(arr, pad_amt, num, axis=-1):
@@ -697,7 +702,7 @@
                           axis=axis)


-def _append_min(arr, pad_amt, num, axis=-1):
+def _append_min(arr, arr1, pad_amt, num, axis=-1):
     """
     Append `pad_amt` median values along `axis`.

@@ -746,7 +751,7 @@
                           for (i, x) in enumerate(arr.shape))

     # Extract slice, calculate min, reshape to add singleton dimension back
-    min_chunk = arr[min_slice].min(axis=axis).reshape(pad_singleton)
+    min_chunk = arr1[min_slice].min(axis=axis).reshape(pad_singleton)

     # Concatenate `arr` with `min_chunk`, extended along `axis` by `pad_amt`
     return np.concatenate((arr, min_chunk.repeat(pad_amt, axis=axis)),
@@ -1311,6 +1316,8 @@
            [10, 10, 10, 10, 10, 10, 10],
            [10, 10, 10, 10, 10, 10, 10]])
     """
+    if mode == "median":
+        raise ValueError("%s is not implemented" % mode)
     if not np.asarray(pad_width).dtype.kind == 'i':
         raise TypeError('`pad_width` must be of integral type.')

@@ -1407,26 +1414,26 @@
     elif mode == 'maximum':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _prepend_max(newmat, pad_before, chunk_before, axis)
-            newmat = _append_max(newmat, pad_after, chunk_after, axis)
+            newmat2 = _prepend_max(newmat, pad_before, chunk_before, axis)
+            newmat = _append_max(newmat2, newmat, pad_after, chunk_after, axis)

     elif mode == 'mean':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _prepend_mean(newmat, pad_before, chunk_before, axis)
-            newmat = _append_mean(newmat, pad_after, chunk_after, axis)
+            newmat2 = _prepend_mean(newmat, pad_before, chunk_before, axis)
+            newmat = _append_mean(newmat2, newmat, pad_after, chunk_after, axis)

     elif mode == 'median':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _prepend_med(newmat, pad_before, chunk_before, axis)
-            newmat = _append_med(newmat, pad_after, chunk_after, axis)
+            newmat2 = _prepend_med(newmat, pad_before, chunk_before, axis)
+            newmat = _append_med(newmat2, newmat, pad_after, chunk_after, axis)

     elif mode == 'minimum':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _prepend_min(newmat, pad_before, chunk_before, axis)
-            newmat = _append_min(newmat, pad_after, chunk_after, axis)
+            newmat2 = _prepend_min(newmat, pad_before, chunk_before, axis)
+            newmat = _append_min(newmat2, newmat, pad_after, chunk_after, axis)

     elif mode == 'reflect':
         for axis, (pad_before, pad_after) in enumerate(pad_width):
```
