### PR TITLE
Bug fix of concatenate + max

### DIFF
--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -307,11 +307,14 @@ def make_grad_chooser(ans, x, axis=None, keepdims=None):
     repeater, _ = repeat_to_match_shape(x, axis, keepdims)
     argmax_locations = x == repeater(ans)
     idx = onp.argwhere(argmax_locations)
-    for i in range(len(idx) - 1):
-        for j in range(i + 1, len(idx)):
-            diff = onp.argwhere(idx[i] != idx[j])
-            if len(diff) == 1 and diff[0] == axis:
-                argmax_locations[tuple(idx[j])] = False
+    idx_ignore_axis = idx.copy()
+    idx_ignore_axis[:, axis] = 0
+    have_seen = set()
+    for i in range(len(idx)):
+        if tuple(idx_ignore_axis[i]) in have_seen:
+            argmax_locations[tuple(idx[i])] = False
+        else:
+            have_seen.add(tuple(idx_ignore_axis[i]))
     return lambda g: repeater(g) * argmax_locations
 anp.max.defgrad(make_grad_chooser)
 anp.min.defgrad(make_grad_chooser)

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -306,6 +306,12 @@ def make_grad_chooser(ans, x, axis=None, keepdims=None):
     """Builds gradient of functions that choose a single item, such as min or max."""
     repeater, _ = repeat_to_match_shape(x, axis, keepdims)
     argmax_locations = x == repeater(ans)
+    idx = onp.argwhere(argmax_locations)
+    for i in range(len(idx) - 1):
+        for j in range(i + 1, len(idx)):
+            diff = onp.argwhere(idx[i] != idx[j])
+            if len(diff) == 1 and diff[0] == axis:
+                argmax_locations[tuple(idx[j])] = False
     return lambda g: repeater(g) * argmax_locations
 anp.max.defgrad(make_grad_chooser)
 anp.min.defgrad(make_grad_chooser)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -349,6 +349,15 @@ def test_concatenate_axis_1_unnamed():
     check_grads(fun, A)
     check_grads(d_fun, A)
 
+def test_concatenate_max():
+    def fun(x):
+        x = np.concatenate((x.max(axis=0).reshape((1, 1)), x))
+        x = np.concatenate((x.max(axis=0).reshape((1, 1)), x))
+        return np.sum(x)
+
+    mat = np.array([[1.]])
+    check_grads(fun, mat)
+
 def test_trace():
     def fun(x): return np.trace(x, offset=offset)
     d_fun = lambda x : to_scalar(grad(fun)(x))


### PR DESCRIPTION
I think this pull request will solve https://github.com/HIPS/autograd/issues/138 .
```argmax_locations```should not include same value indices.
Only first one should be included.

But this might be slow for a large array because I'm using ```O(len(idx) ** 2)``` for loops.

If this pull request seems correct, I will modify https://github.com/HIPS/autograd/pull/140 .