### PR TITLE
Add numpy.ndarray.astype()

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -254,6 +254,24 @@ class CalculationTape(list):
     def __hash__(self):
         return id(self)
 
+class BoolNode(Node):
+    __slots__ = []
+    @staticmethod
+    def zeros_like(value):
+        return False
+    @staticmethod
+    def cast(value, example):
+        return cast(value, cast_to_bool)
+
+class IntNode(Node):
+    __slots__ = []
+    @staticmethod
+    def zeros_like(value):
+        return 0
+    @staticmethod
+    def cast(value, example):
+        return cast(value, cast_to_int)
+
 class FloatNode(Node):
     __slots__ = []
     @staticmethod
@@ -263,7 +281,19 @@ class FloatNode(Node):
     def cast(value, example):
         return cast(value, cast_to_float)
 
+Node.type_mappings[bool] = BoolNode
+Node.type_mappings[int] = IntNode
 Node.type_mappings[float] = FloatNode
+
+def cast_to_bool(x):
+    if np.iscomplexobj(x):
+        x = np.real(x)
+    return bool(x)
+
+def cast_to_int(x):
+    if np.iscomplexobj(x):
+        x = np.real(x)
+    return int(x)
 
 def cast_to_float(x):
     if np.iscomplexobj(x):

--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import numpy as np
 
-from autograd.core import (Node, FloatNode, primitive, cast,
+from autograd.core import (Node, BoolNode, IntNode, FloatNode, primitive, cast,
                            differentiable_ops, nondifferentiable_ops, getval)
 from . import numpy_wrapper as anp
 from .use_gpu_numpy import use_gpu_numpy
@@ -83,6 +83,9 @@ class ArrayNode(Node):
     def __le__(self, other): return anp.less_equal(self, other)
     def __abs__(self): return anp.abs(self)
 
+    def astype(self, dtype, order='K', casting='unsafe', subok=True, copy=True):
+        return anp.astype(self, dtype, order, casting, subok, copy)
+
 def new_array_node(value, tapes):
     try:
         return array_dtype_mappings[value.dtype](value, tapes)
@@ -91,6 +94,13 @@ def new_array_node(value, tapes):
 Node.type_mappings[anp.ndarray] = new_array_node
 
 array_dtype_mappings = {}
+for bool_type in [anp.bool8]:
+    array_dtype_mappings[anp.dtype(bool_type)] = ArrayNode
+    Node.type_mappings[bool_type] = BoolNode
+for int_type in [anp.int8, anp.int16, anp.int32, anp.int64,
+                 anp.uint8, anp.uint16, anp.uint32, anp.uint64]:
+    array_dtype_mappings[anp.dtype(int_type)] = ArrayNode
+    Node.type_mappings[int_type] = IntNode
 for float_type in [anp.float64, anp.float32, anp.float16]:
     array_dtype_mappings[anp.dtype(float_type)] = ArrayNode
     Node.type_mappings[float_type] = FloatNode

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -181,6 +181,19 @@ anp.frexp.defgrad(lambda ans, x: lambda g : g[0] * 2.0 ** -ans[1])
 
 # ----- Trickier grads -----
 
+@primitive
+def astype(ary, dtype, order='K', casting='unsafe', subok=True, copy=True):
+    return ary.astype(dtype, order, casting, subok, copy)
+def make_grad_astype(ans, ary, dtype, order='K', casting='unsafe', subok=True, copy=True):
+    if dtype in (anp.int8, anp.int16, anp.int32, anp.int64,
+                 anp.uint8, anp.uint16, anp.uint32, anp.uint64,
+                 anp.bool8):
+        return lambda g: anp.zeros(g.shape)
+    else:
+        return I
+anp.astype = astype
+anp.astype.defgrad(make_grad_astype)
+
 def make_grad_diff(ans, a, n=1, axis=-1):
     nd = len(a.shape)
     sl1 = [slice(None)]*nd

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -15,15 +15,24 @@ from autograd.container_types import ListNode, TupleNode, make_tuple
 if use_gpu_numpy():
     garray_obj = np.garray
     array_types = (np.ndarray, garray_obj)
-    EPS, RTOL, ATOL = 1e-4, 1e-2, 1e-2
+    initial_eps_rtol_atol = 1e-4, 1e-2, 1e-2
 else:
     garray_obj = ()
     array_types = (np.ndarray,)
-    EPS, RTOL, ATOL = 1e-3, 1e-3, 1e-3
+    initial_eps_rtol_atol = 1e-4, 1e-4, 1e-6
+EPS, RTOL, ATOL = initial_eps_rtol_atol
+
+def set_eps_rtol_atol(eps, rtol, atol):
+    global EPS, RTOL, ATOL
+    EPS, RTOL, ATOL = eps, rtol, atol
+
+def reset_eps_rtol_atol():
+    global EPS, RTOL, ATOL
+    EPS, RTOL, ATOL = initial_eps_rtol_atol
 
 def nd(f, *args):
     unary_f = lambda x : f(*x)
-    return unary_nd(unary_f, args)
+    return unary_nd(unary_f, args, EPS)
 
 def unary_nd(f, x, eps=EPS):
     if isinstance(x, array_types):
@@ -34,15 +43,15 @@ def unary_nd(f, x, eps=EPS):
         else:
             nd_grad = np.zeros(x.shape)
         for dims in it.product(*list(map(range, x.shape))):
-            nd_grad[dims] = unary_nd(indexed_function(f, x, dims), x[dims])
+            nd_grad[dims] = unary_nd(indexed_function(f, x, dims), x[dims], eps)
         return nd_grad
     elif isinstance(x, tuple):
-        return tuple([unary_nd(indexed_function(f, tuple(x), i), x[i])
+        return tuple([unary_nd(indexed_function(f, tuple(x), i), x[i], eps)
                       for i in range(len(x))])
     elif isinstance(x, dict):
-        return {k : unary_nd(indexed_function(f, x, k), v) for k, v in iteritems(x)}
+        return {k : unary_nd(indexed_function(f, x, k), v, eps) for k, v in iteritems(x)}
     elif isinstance(x, list):
-        return [unary_nd(indexed_function(f, x, i), v) for i, v in enumerate(x)]
+        return [unary_nd(indexed_function(f, x, i), v, eps) for i, v in enumerate(x)]
     elif np.iscomplexobj(x):
         result = (f(x +    eps/2) - f(x -    eps/2)) / eps \
             - 1j*(f(x + 1j*eps/2) - f(x - 1j*eps/2)) / eps
@@ -66,10 +75,10 @@ def check_equivalent(A, B, rtol=RTOL, atol=ATOL):
     assert base_class(type(A)) is base_class(type(B)),\
         "Types are: {0} and {1}".format(type(A), type(B))
     if isinstance(A, (tuple, list)):
-        for a, b in zip(A, B): check_equivalent(a, b)
+        for a, b in zip(A, B): check_equivalent(a, b, rtol, atol)
     elif isinstance(A, dict):
         assert len(A) == len(B)
-        for k in A: check_equivalent(A[k], B[k])
+        for k in A: check_equivalent(A[k], B[k], rtol, atol)
     else:
         if isinstance(A, np.ndarray):
             assert A.shape == B.shape, "Shapes are analytic: {0} and numeric: {1}".format(
@@ -85,7 +94,7 @@ def check_grads(fun, *args):
         raise Exception("No args given")
     exact = tuple([grad(fun, i)(*args) for i in range(len(args))])
     numeric = nd(fun, *args)
-    check_equivalent(exact, numeric)
+    check_equivalent(exact, numeric, RTOL, ATOL)
 
 def to_scalar(x):
     if isinstance(x, list)  or isinstance(x, ListNode) or \

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -19,7 +19,7 @@ if use_gpu_numpy():
 else:
     garray_obj = ()
     array_types = (np.ndarray,)
-    EPS, RTOL, ATOL = 1e-4, 1e-4, 1e-6
+    EPS, RTOL, ATOL = 1e-3, 1e-3, 1e-3
 
 def nd(f, *args):
     unary_f = lambda x : f(*x)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -15,7 +15,7 @@ def test_nograd():
     fun = lambda x: np.allclose(x, (x*3.0)/3.0)
     try:
         grad(fun)(np.array([1., 2., 3.]))
-    except TypeError:
+    except NotImplementedError:
         pass
     else:
         raise Exception('Expected non-differentiability exception')

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -868,7 +868,9 @@ def test_maximum_equal_values_2d():
     check_grads(d_fun, 2.0)
 
 def test_astype():
+    set_eps_rtol_atol(1e-3, 1e-3, 1e-3)
     for dtype in (np.bool8, np.int32, np.int64, np.float32, np.float64):
         def fun(x): return to_scalar(x.astype(dtype))
         mat = npr.randn(10, 11)
         check_grads(fun, mat)
+    reset_eps_rtol_atol()

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -868,9 +868,13 @@ def test_maximum_equal_values_2d():
     check_grads(d_fun, 2.0)
 
 def test_astype():
-    set_eps_rtol_atol(1e-3, 1e-3, 1e-3)
     for dtype in (np.bool8, np.int32, np.int64, np.float32, np.float64):
+        if dtype == np.float32:
+            set_eps_rtol_atol(1e-3, 1e-3, 1e-3)
+
         def fun(x): return to_scalar(x.astype(dtype))
         mat = npr.randn(10, 11)
         check_grads(fun, mat)
-    reset_eps_rtol_atol()
+
+        if dtype == np.float32:
+            reset_eps_rtol_atol()

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -866,3 +866,9 @@ def test_maximum_equal_values_2d():
     check_grads(d_fun, -1.0)
     check_grads(fun, 2.0)
     check_grads(d_fun, 2.0)
+
+def test_astype():
+    for dtype in (np.bool8, np.int32, np.int64, np.float32, np.float64):
+        def fun(x): return to_scalar(x.astype(dtype))
+        mat = npr.randn(10, 11)
+        check_grads(fun, mat)


### PR DESCRIPTION
I added numpy.ndarray.astype().
Even if you use integers, the derivative is float64.

I changed to `EPS, RTOL, ATOL = 1e-3, 1e-3, 1e-3`.
This change is necessary for float32.
