### PR TITLE
Removed setup_requires parameter in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(
     author_email="maclaurin@physics.harvard.edu, duvenaud@cs.toronto.edu, mattjj@csail.mit.edu",
     packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats'],
     install_requires=['numpy>=1.10', 'scipy>=0.17', 'future>=0.15.2'],
-    setup_requires=['numpy>=1.10', 'scipy>=0.17'],
     keywords=['Automatic differentiation', 'backpropagation', 'gradients',
               'machine learning', 'optimization', 'neural networks',
               'Python', 'Numpy', 'Scipy'],


### PR DESCRIPTION
Hi,

I removed the setup_requires parameter in setup.py, which forced to have both numpy and scipy installed before installing autograd (and all packages that have autograd as a dependency). Running

`pip install autograd`

would fail in a clean environment, now it works fine.

Hope this helps!