### PR TITLE
Workaround for partial __name__

### DIFF
--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -179,10 +179,11 @@ def multigrad_dict(fun):
 
 def attach_name_and_doc(fun, argnum, opname):
     namestr = "{op}_{fun}_wrt_argnum_{argnum}".format(
-        op=opname.lower(), fun=fun.__name__, argnum=argnum)
+        op=opname.lower(), fun=getattr(fun, __name__, '[unknown name]'), argnum=argnum)
     docstr = "{op} of function {fun} with respect to argument number {argnum}. " \
-        "Has the same arguments as {fun} but the return value has type of" \
-        "argument {argnum}".format(op=opname, fun=fun.__name__, argnum=argnum)
+        "Has the same arguments as {fun} but the return value has type of " \
+        "argument {argnum}.".format(op=opname, fun=getattr(fun, __name__, '[unknown name]'),
+        argnum=argnum)
 
     def wrap(gradfun):
         try:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import warnings
+from functools import partial
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd.util import *
@@ -144,3 +145,8 @@ def test_deprecated_defgrad_wrapper():
     mat1 = npr.randn(2, 2)
     mat2 = npr.randn(2, 2)
     check_grads(fun, mat1, mat2)
+
+def test_partial():
+    def f(x, y):
+        return x
+    grad(partial(f, y=1))


### PR DESCRIPTION
Also add test for grad of partial, fix typo in attached docstring and add fullstop to the end of attached docstring. Fixes https://github.com/HIPS/autograd/issues/167.