### PR TITLE
Use integers for array indexing in examples

### DIFF
--- a/examples/convnet.py
+++ b/examples/convnet.py
@@ -110,7 +110,7 @@ class maxpool_layer(object):
         for i in [0, 1]:
             pool_width = self.pool_shape[i]
             img_width = inputs.shape[i + 2]
-            new_shape += (pool_width, img_width / pool_width)
+            new_shape += (pool_width, img_width // pool_width)
         result = inputs.reshape(new_shape)
         return np.max(np.max(result, axis=2), axis=3)
 

--- a/examples/fluidsim/wing.py
+++ b/examples/fluidsim/wing.py
@@ -86,9 +86,9 @@ def simulate(vx, vy, num_time_steps, occlusion, ax=None, render=False):
 
     # Initialize smoke bands.
     red_smoke = np.zeros((rows, cols))
-    red_smoke[rows/4:rows/2] = 1
+    red_smoke[rows//4:rows//2] = 1
     blue_smoke = np.zeros((rows, cols))
-    blue_smoke[rows/2:3*rows/4] = 1
+    blue_smoke[rows//2:3*rows//4] = 1
 
     print("Running simulation...")
     vx, vy = project(vx, vy, occlusion)

--- a/examples/mixture_variational_inference.py
+++ b/examples/mixture_variational_inference.py
@@ -21,7 +21,7 @@ def diag_gaussian_log_density(x, mu, log_std):
 
 def unpack_gaussian_params(params):
     # Variational dist is a diagonal Gaussian.
-    D = np.shape(params)[0] / 2
+    D = np.shape(params)[0] // 2
     mean, log_std = params[:D], params[D:]
     return mean, log_std
 

--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -15,7 +15,7 @@ def diag_gaussian_log_density(x, mu, log_std):
 
 def unpack_gaussian_params(params):
     # Params of a diagonal Gaussian.
-    D = np.shape(params)[-1] / 2
+    D = np.shape(params)[-1] // 2
     mean, log_std = params[:, :D], params[:, D:]
     return mean, log_std
 
@@ -126,4 +126,3 @@ if __name__ == '__main__':
     # The optimizers provided can optimize lists, tuples, or dicts of parameters.
     optimized_params = adam(objective_grad, combined_init_params, step_size=step_size,
                             num_iters=num_epochs * num_batches, callback=print_perf)
-


### PR DESCRIPTION
This means you don't get the following warning when running them:
```
VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
```