### PR TITLE
Dtype support

### DIFF
--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -22,8 +22,8 @@ def grad(fun, argnum=0):
     def gradfun(*args,**kwargs):
         args = list(args)
         args[argnum] = safe_type(args[argnum])
-        vjp, _ = make_vjp(scalar_fun, argnum)(*args, **kwargs)
-        return vjp(1.0)
+        vjp, ans = make_vjp(scalar_fun, argnum)(*args, **kwargs)
+        return vjp(cast_to_same_dtype(1.0, ans))
 
     return gradfun
 
@@ -213,3 +213,9 @@ def as_scalar(x):
             "Output {} can't be cast to float. "
             "Function grad requires a scalar-valued function. "
             "Try jacobian or elementwise_grad.".format(getval(x)))
+
+def cast_to_same_dtype(value, example):
+    if hasattr(example, 'dtype') and example.dtype.type is not np.float64:
+        return np.array(value, dtype=example.dtype)
+    else:
+        return value

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -150,3 +150,14 @@ def test_partial():
     def f(x, y):
         return x
     grad(partial(f, y=1))
+
+def test_dtypes():
+    def f(x):
+        return np.sum(x**2)
+
+    # Array y with dtype np.float32
+    y = np.random.randn(10, 10).astype(np.float32)
+    assert grad(f)(y).dtype.type is np.float32
+
+    y = np.random.randn(10, 10).astype(np.float16)
+    assert grad(f)(y).dtype.type is np.float16


### PR DESCRIPTION
Support for different float dtypes, such as float32 and float16. Automatically infer the correct dtype. This is handy because the smaller floats use less memory and are faster. Fixes https://github.com/HIPS/autograd/issues/163.