### PR TITLE
Added checkpointing_grad convenience wrapper

### DIFF
--- a/autograd/__init__.py
+++ b/autograd/__init__.py
@@ -3,4 +3,5 @@ from .core import primitive
 from . import container_types
 from .convenience_wrappers import (grad, multigrad, multigrad_dict, elementwise_grad,
                                    value_and_grad, grad_and_aux, hessian_vector_product,
-                                   hessian, jacobian, vector_jacobian_product, grad_named)
+                                   hessian, jacobian, vector_jacobian_product, grad_named,
+                                   checkpointed_grad)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -167,9 +167,9 @@ def test_matrix_jacobian_product():
     check_equivalent(np.tensordot(V, J), vector_jacobian_product(fun)(a, V))
 
 def test_tensor_jacobian_product():
-    fun = lambda a: np.sum(np.roll(np.sin(a), 1), axis=2, keepdims=False)
+    fun = lambda a: np.roll(np.sin(a), 1)
     a = npr.randn(5, 4, 3)
-    V = npr.randn(5, 4)
+    V = npr.randn(5, 4, 3)
     J = jacobian(fun)(a)
     check_equivalent(np.tensordot(V, J, axes=np.ndim(V)), vector_jacobian_product(fun)(a, V))
 


### PR DESCRIPTION
This is a simple implementation of checkpointing. It requires the user to express the function for which they want the gradient as a composition of functions. Something like:

```python
def fun(x):
    return fun3(fun2(fun1(x)))
```
then
```python
grad(fun)
checkpointing_grad(fun1, fun2, fun3)
```
will compute the same thing, but with different memory use and computational time.

The following crude test shows that the trade-off may be quite good:
```python
%load_ext memory_profiler

from autograd import grad, checkpointed_grad
import autograd.numpy as np

def f(a):
    b = a**2 + 1
    c = np.sin(b)
    d = c**2 + 1
    e = np.sin(d)
    return e

A = np.random.randn(1000000)

%timeit grad(lambda x: np.sum(f(f(f(x)))))(A)
%timeit checkpointed_grad(f, f, f, np.sum)(A)

%memit grad(lambda x: np.sum(f(f(f(x)))))(A)
%memit checkpointed_grad(f, f, f, np.sum)(A)
```
outputs
```
1 loop, best of 3: 875 ms per loop
1 loop, best of 3: 1.41 s per loop
peak memory: 275.34 MiB, increment: 105.03 MiB
peak memory: 177.91 MiB, increment: 25.11 MiB
```
on my machine.