### PR TITLE
Fixes #185

### DIFF
--- a/autograd/numpy/fft.py
+++ b/autograd/numpy/fft.py
@@ -13,7 +13,7 @@ wrap_namespace(ffto.__dict__, globals())
 def fft_defvjp(fft_fun):
     def fft_grad(g, ans, vs, gvs, x, *args, **kwargs):
         check_no_repeated_axes(*args, **kwargs)
-        return match_complex(vs, truncate_pad(fft_fun(g, *args, **kwargs), vs.shape))
+        return match_complex(vs, truncate_pad(fft_fun(g, *args, **kwargs).conjugate(), vs.shape))
     fft_fun.defvjp(fft_grad)
 
 for fft_fun in (fft, ifft, fft2, ifft2, fftn, ifftn):


### PR DESCRIPTION
Potential fix of #185 (if that is indeed a bug). It gives correct result for the following function.

```
def func(x):
    r1 = fft.fftn(x)
    u = (abs(r1)**2)
    return u.sum()

def vfunc(x):
    # for approx_fprime, unpack complex numbers
    return func(x.reshape(4, 4, 2).view(dtype='complex128').reshape(4, 4))

dfunc = autograd.grad(func)

def dfunc2(x):
    # manual auto-diff
    r1 = fft.fftn(x)
    u = (abs(r1)**2)
    _r1 = r1 * 2
    _x = fft.ifftn(_r1) * _r1.size
    return _x
```