### PR TITLE
cache the nodes produced by SequenceNode.__getitem__

### DIFF
--- a/autograd/container_types.py
+++ b/autograd/container_types.py
@@ -7,9 +7,16 @@ from functools import partial
 import numpy as np
 
 class SequenceNode(Node):
-    __slots__ = []
+    __slots__ = ['elements']
+    def __init__(self, *args, **kwargs):
+        self.elements = {}
+        super(SequenceNode, self).__init__(*args, **kwargs)
     def __getitem__(self, idx):
-        return sequence_take(self, idx)
+        # slices are not hashable: https://bugs.python.org/issue408326
+        key = (idx.start, idx.stop, idx.step) if isinstance(idx, slice) else idx
+        if key not in self.elements:
+            self.elements[key] = sequence_take(self, idx)
+        return self.elements[key]
     def __len__(self):
         return len(self.value)
 


### PR DESCRIPTION
With the current SequenceNode implementation, every call to `__getitem__` returns a new Node instance. Here's a contrived example:

```python
import autograd.numpy as np
from autograd import grad

def f(tup):
    x = np.array([tup[0] for _ in xrange(100)])
    return np.sum(x)

grad(f)((1.,))  # more than 100 nodes created
```

An alternative, implemented here, is to make SequenceNode cache the Nodes returned from its `__getitem__` method. In the above example, that means only 5 nodes are created (independent of the size of the `xrange`).

This memoized version can reduce the graph overhead by cutting out redundant nodes (meaning both memory and time savings, at least in some cases). In addition, it makes the traced graph cleaner; this came up as I was playing with translating the autograd graph into other representations, and I was annoyed by having many Nodes refer to the same sequence element.

However, this implementation introduces some new costs. In addition to requiring a new dict for each SequenceNode instance and a lookup in that dict for each call to `SequenceNode.__getitem__`, my implementation also introduces an `isinstance(idx, slice)` check. Unfortunately, [slices in Python are not hashable](https://bugs.python.org/issue408326) even though they are isomorphic to 3-tuples.

If those costs are too high for common use cases, I can solve my graph representation problem in other ways.

By the way, I think this implementation makes sense because our SequenceNodes are immutable, since this code throws an error on the master branch:

```python
def f(lst):
    lst[1] = 5.
    return sum(lst)
grad(f)([1., 2., 3.])  # TypeError: does not support item assignment
```

Thoughts?