### PR TITLE
An interp that supports gradient

### DIFF
--- a/autograd/numpy/__init__.py
+++ b/autograd/numpy/__init__.py
@@ -6,3 +6,4 @@ from .numpy_wrapper import *
 from . import linalg
 from . import fft
 from . import random
+from .numpy_interp import interp

--- a/autograd/numpy/numpy_interp.py
+++ b/autograd/numpy/numpy_interp.py
@@ -1,0 +1,53 @@
+import numpy as np
+from autograd import numpy as anp
+from autograd import primitive
+
+def interp(x, xp, yp, left=None, right=None):
+    """ Differentiable against yp """
+    if left is None:
+        left = yp[0]
+    if right is None: right = yp[-1]
+
+    xp = anp.concatenate([[xp[0]], xp, [xp[-1]]])
+    yp = anp.concatenate([anp.array([left]), yp, anp.array([right])])
+
+    m = make_matrix(x, xp)
+    y = anp.inner(m, yp)
+    return y
+
+def W(r, D):
+    """ Convolution kernel for linear interpolation.
+        D is the differences of xp.
+    """
+    mask = D == 0
+    D[mask] = 1.0
+    Wleft = 1.0 + r[1:] / D
+    Wright = 1.0 - r[:-1] / D
+    # edges
+    Wleft = np.where(mask, 0, Wleft)
+    Wright = np.where(mask, 0, Wright)
+    Wleft = np.concatenate([[0], Wleft])
+    Wright = np.concatenate([Wright, [0]])
+    W = np.where(r < 0, Wleft, Wright)
+    W = np.where(r == 0, 1.0, W)
+    W = np.where(W < 0, 0, W)
+    return W
+
+def make_matrix(x, xp):
+    D = np.diff(xp)
+    w = []
+    v0 = np.zeros(len(xp))
+    v0[0] = 1.0
+    v1 = np.zeros(len(xp))
+    v1[-1] = 1.0
+    for xi in x:
+        # left, use left
+        if xi < xp[0]: v = v0
+        # right , use right
+        elif xi > xp[-1]: v = v1
+        else:
+            v = W(xi - xp, D)
+            v[0] = 0
+            v[-1] = 0
+        w.append(v)
+    return np.array(w)

--- a/tests/test_numpy_interp.py
+++ b/tests/test_numpy_interp.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+import warnings
+
+import autograd.numpy as np
+import autograd.numpy.random as npr
+from autograd.util import *
+from autograd import grad
+
+npr.seed(1)
+
+def test_interp():
+    x = np.arange(10) * 1.0
+    xp = np.arange(10) * 1.0
+    yp = np.arange(10) * 1.0
+    def fun(yp): return to_scalar(np.interp(x, xp, yp))
+    def dfun(yp): return to_scalar(grad(fun)(yp))
+    print(fun(yp), dfun(yp))
+    check_grads(fun, yp)
+    check_grads(dfun, yp)

--- a/tests/test_numpy_interp.py
+++ b/tests/test_numpy_interp.py
@@ -6,14 +6,47 @@ import autograd.numpy.random as npr
 from autograd.util import *
 from autograd import grad
 
+from numpy import interp as ninterp
+from numpy.testing import assert_allclose
+
 npr.seed(1)
 
 def test_interp():
-    x = np.arange(10) * 1.0
+    x = np.arange(-20, 20, 0.1)
     xp = np.arange(10) * 1.0
-    yp = np.arange(10) * 1.0
+    yp = xp ** 0.5 + npr.normal(size=xp.shape)
     def fun(yp): return to_scalar(np.interp(x, xp, yp))
     def dfun(yp): return to_scalar(grad(fun)(yp))
-    print(fun(yp), dfun(yp))
+
     check_grads(fun, yp)
     check_grads(dfun, yp)
+
+def test_interp_edge():
+    x = np.arange(-20, 20, 0.1)
+    xp = np.arange(10) * 1.0
+    yp = xp ** 0.5 + npr.normal(size=xp.shape)
+    def fun(yp): return to_scalar(np.interp(x, xp, yp, left=-1, right=-1))
+    def dfun(yp): return to_scalar(grad(fun)(yp))
+
+    check_grads(fun, yp)
+    check_grads(dfun, yp)
+
+def test_interp_correctness():
+    x = np.arange(-100, 100, 0.1)
+    xp = np.arange(10) * 1.0
+    yp = xp ** 2
+
+    y1 = ninterp(x, xp, yp)
+    y2 = np.interp(x, xp, yp)
+
+    assert_allclose(y1, y2)
+
+def test_interp_correctness_edge():
+    x = np.arange(-100, 100, 0.1)
+    xp = np.arange(10) * 1.0
+    yp = xp ** 2
+
+    y1 = ninterp(x, xp, yp, left=-1, right=-1)
+    y2 = np.interp(x, xp, yp, left=-1, right=-1)
+
+    assert_allclose(y1, y2)

--- a/tests/test_numpy_interp.py
+++ b/tests/test_numpy_interp.py
@@ -9,11 +9,10 @@ from autograd import grad
 from numpy import interp as ninterp
 from numpy.testing import assert_allclose
 
-npr.seed(1)
-
 def test_interp():
     x = np.arange(-20, 20, 0.1)
     xp = np.arange(10) * 1.0
+    npr.seed(1)
     yp = xp ** 0.5 + npr.normal(size=xp.shape)
     def fun(yp): return to_scalar(np.interp(x, xp, yp))
     def dfun(yp): return to_scalar(grad(fun)(yp))
@@ -24,6 +23,7 @@ def test_interp():
 def test_interp_edge():
     x = np.arange(-20, 20, 0.1)
     xp = np.arange(10) * 1.0
+    npr.seed(1)
     yp = xp ** 0.5 + npr.normal(size=xp.shape)
     def fun(yp): return to_scalar(np.interp(x, xp, yp, left=-1, right=-1))
     def dfun(yp): return to_scalar(grad(fun)(yp))
@@ -34,7 +34,8 @@ def test_interp_edge():
 def test_interp_correctness():
     x = np.arange(-100, 100, 0.1)
     xp = np.arange(10) * 1.0
-    yp = xp ** 2
+    npr.seed(1)
+    yp = xp ** 0.5 + npr.normal(size=xp.shape)
 
     y1 = ninterp(x, xp, yp)
     y2 = np.interp(x, xp, yp)
@@ -44,7 +45,8 @@ def test_interp_correctness():
 def test_interp_correctness_edge():
     x = np.arange(-100, 100, 0.1)
     xp = np.arange(10) * 1.0
-    yp = xp ** 2
+    npr.seed(1)
+    yp = xp ** 0.5 + npr.normal(size=xp.shape)
 
     y1 = ninterp(x, xp, yp, left=-1, right=-1)
     y2 = np.interp(x, xp, yp, left=-1, right=-1)


### PR DESCRIPTION
I am not sure if this is the right approach. It is impossible (at least when I fiddled) to directly use numpy.interp as an implementation of vjp of itself, because the width of the windows must be fixed. Therefore I put up a reimplementation of interp as a matrix product. I am not using a sparse matrix because I don't know if it is appropiate to pull in scipy.sparse for a numpy gradient. 

The current version only allows propagating the gradient on the yp argument. It is trivial to add others. Adding support to period != None mode should be possible too.

But we need to convince ourself if this is the right approach to support non-trivial gradient of numpy functions. I think at least numpy.bincount will be similar to this; there may be more in the horizon.

This code may be expanded to handle other real space convolution based operators (with a finite support), I think. 


