### PR TITLE
simplify repeat_to_match_shape using vs.zeros()

### DIFF
--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -190,14 +190,13 @@ anp.transpose.defvjp(grad_transpose)
 def repeat_to_match_shape(g, vs, axis, keepdims):
     """Returns the array g repeated along axis to fit vector space vs.
        Also returns the number of repetitions of the array."""
-    zero = vs.zeros()
-    if zero.shape == ():
+    if vs.shape == ():
       return g, 1
     axis = list(axis) if isinstance(axis, tuple) else axis
-    shape = anp.array(zero.shape)
+    shape = anp.array(vs.shape)
     shape[axis] = 1
-    num_reps = anp.prod(anp.array(zero.shape)[axis])
-    return anp.reshape(g, shape) + zero, num_reps
+    num_reps = anp.prod(anp.array(vs.shape)[axis])
+    return anp.reshape(g, shape) + vs.zeros(), num_reps
 
 def grad_np_sum(g, ans, vs, gvs, x, axis=None, keepdims=False):
     return repeat_to_match_shape(g, vs, axis, keepdims)[0]

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -193,9 +193,9 @@ def repeat_to_match_shape(g, vs, axis, keepdims):
     if vs.shape == ():
       return g, 1
     axis = list(axis) if isinstance(axis, tuple) else axis
-    shape = anp.array(vs.shape)
+    shape = onp.array(vs.shape)
     shape[axis] = 1
-    num_reps = anp.prod(anp.array(vs.shape)[axis])
+    num_reps = onp.prod(onp.array(vs.shape)[axis])
     return anp.reshape(g, shape) + vs.zeros(), num_reps
 
 def grad_np_sum(g, ans, vs, gvs, x, axis=None, keepdims=False):

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -190,26 +190,14 @@ anp.transpose.defvjp(grad_transpose)
 def repeat_to_match_shape(g, vs, axis, keepdims):
     """Returns the array g repeated along axis to fit vector space vs.
        Also returns the number of repetitions of the array."""
-    shape = vs.shape
-    if shape == ():
-        return g, 1
-    elif axis is None:
-        if keepdims:
-            g = anp.sum(g)
-        return anp.full(shape, g, dtype=vs.dtype), anp.prod(shape)
-    elif isinstance(axis, int):
-        if not keepdims:
-            g = anp.expand_dims(g, axis)
-        return anp.repeat(g, shape[axis], axis), shape[axis]
-    elif isinstance(axis, tuple):
-        repeats  = [shape[i] if i in axis else 1 for i in range(len(shape))]
-        expanded = [shape[i] if i not in axis else 1 for i in range(len(shape))]
-        num_reps = anp.prod(anp.array(shape)[list(axis)])
-        if not keepdims:
-            g = anp.reshape(g, expanded)
-        return anp.tile(g, repeats), num_reps
-    else:
-        raise Exception('Axis type {} not valid'.format(type(axis)))
+    zero = vs.zeros()
+    if zero.shape == ():
+      return g, 1
+    axis = list(axis) if isinstance(axis, tuple) else axis
+    shape = anp.array(zero.shape)
+    shape[axis] = 1
+    num_reps = anp.prod(anp.array(zero.shape)[axis])
+    return anp.reshape(g, shape) + zero, num_reps
 
 def grad_np_sum(g, ans, vs, gvs, x, axis=None, keepdims=False):
     return repeat_to_match_shape(g, vs, axis, keepdims)[0]


### PR DESCRIPTION
This PR simplifies the implementation of `repeat_to_match_shape` to use numpy broadcasting and `vs.zeros()`.

Let me know if you see any problems with this approach. Otherwise I'll merge it at some point in the next few days.