### PR TITLE
Fix float shape parameter in data.py

### DIFF
--- a/examples/data.py
+++ b/examples/data.py
@@ -23,7 +23,7 @@ def plot_images(images, ax, ims_per_row=5, padding=5, digit_dimensions=(28, 28),
                 cmap=matplotlib.cm.binary, vmin=None, vmax=None):
     """Images should be a (N_images x pixels) matrix."""
     N_images = images.shape[0]
-    N_rows = N_images // ims_per_row + 1
+    N_rows = (N_images - 1) // ims_per_row + 1
     pad_value = np.min(images.ravel())
     concat_images = np.full(((digit_dimensions[0] + padding) * N_rows + padding,
                              (digit_dimensions[1] + padding) * ims_per_row + padding), pad_value)

--- a/examples/data.py
+++ b/examples/data.py
@@ -23,7 +23,7 @@ def plot_images(images, ax, ims_per_row=5, padding=5, digit_dimensions=(28, 28),
                 cmap=matplotlib.cm.binary, vmin=None, vmax=None):
     """Images should be a (N_images x pixels) matrix."""
     N_images = images.shape[0]
-    N_rows = np.ceil(float(N_images) / ims_per_row)
+    N_rows = N_images // ims_per_row + 1
     pad_value = np.min(images.ravel())
     concat_images = np.full(((digit_dimensions[0] + padding) * N_rows + padding,
                              (digit_dimensions[1] + padding) * ims_per_row + padding), pad_value)


### PR DESCRIPTION
I get an error when running the variational_autoencoder.py example (and probably other examples which call the `plot_images` function from data.py). This is caused by trying to use a float as part of a shape tuple. Line 28 of data.py is
```
    N_rows = np.ceil(float(N_images) / ims_per_row)
```
This creates a float (np.ceil returns a float), which is then used here in a shape parameter a couple of lines below:
```
    concat_images = np.full(((digit_dimensions[0] + padding) * N_rows + padding,
                             (digit_dimensions[1] + padding) * ims_per_row + padding), pad_value)
```
This is trivial to fix...