### PR TITLE
simplify and generalize grad_einsum by using numpy's new _parse_einsum_input

### DIFF
--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -383,18 +383,6 @@ anp.atleast_1d.defvjp(grad_reshape_list)
 anp.atleast_2d.defvjp(grad_reshape_list)
 anp.atleast_3d.defvjp(grad_reshape_list)
 
-# @primitive
-# def parse_einsum_input(*args):
-#     return _parse_einsum_input(args)
-# def grad_parse_einsum_input(argnum, g, ans, vs, gvs, args, kwargs):
-#     if isinstance(args[0], string_types):  # using "ijk" convention
-#         pass
-#     else:  # using (op0, sublist0, op1, sublist1, ..., sublistout) convention
-#         pass
-
-
-# parse_einsum_input.defvjp(grad_parse_einsum_input, argnum=2)
-
 def grad_einsum(argnum, g, ans, vs, gvs, operands, kwargs):
     if isinstance(operands[0], string_types):  # using "ijk" convention.
         in_subs, out_subs, _ = _parse_einsum_input(tuple(map(getval, operands)))

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -397,7 +397,7 @@ anp.atleast_3d.defvjp(grad_reshape_list)
 
 def grad_einsum(argnum, g, ans, vs, gvs, operands, kwargs):
     if isinstance(operands[0], string_types):  # using "ijk" convention.
-        in_subs, out_subs, _ = _parse_einsum_input(operands)
+        in_subs, out_subs, _ = _parse_einsum_input(tuple(map(getval, operands)))
         operands = operands[1:]
 
         in_subs_list = in_subs.split(',')

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 import numpy as onp
 import operator as op
+from numpy.core.einsumfunc import _parse_einsum_input, einsum_symbols_set
 
 from autograd.core import primitive, getval, vspace
 from . import numpy_wrapper as anp
 from .numpy_extra import ArrayNode, take, array_types
 from builtins import range, zip
 from future.utils import string_types
+import string
 
 # ----- Functions that are constant w.r.t. continuous inputs -----
 
@@ -381,29 +383,55 @@ anp.atleast_1d.defvjp(grad_reshape_list)
 anp.atleast_2d.defvjp(grad_reshape_list)
 anp.atleast_3d.defvjp(grad_reshape_list)
 
+# @primitive
+# def parse_einsum_input(*args):
+#     return _parse_einsum_input(args)
+# def grad_parse_einsum_input(argnum, g, ans, vs, gvs, args, kwargs):
+#     if isinstance(args[0], string_types):  # using "ijk" convention
+#         pass
+#     else:  # using (op0, sublist0, op1, sublist1, ..., sublistout) convention
+#         pass
+
+
+# parse_einsum_input.defvjp(grad_parse_einsum_input, argnum=2)
+
 def grad_einsum(argnum, g, ans, vs, gvs, operands, kwargs):
-    # Gradient of einsum is obtained by swapping outgrad with the argument
-    # being differentiated wrt.
     if isinstance(operands[0], string_types):  # using "ijk" convention.
-        subscripts, operands = operands[0], operands[1:]
-        if not '->' in subscripts:
-            raise NotImplementedError("Need indices on both sides.")
+        in_subs, out_subs, _ = _parse_einsum_input(operands)
+        operands = operands[1:]
+
+        in_subs_list = in_subs.split(',')
         op_num = argnum - 1
-        input_subs, output_subs = subscripts.split('->')
-        input_subs_list = input_subs.split(',')
-        subs_wrt = input_subs_list[op_num]
-        rest_of_ops = operands[:op_num] + operands[op_num + 1:]
-        rest_of_subs = input_subs_list[:op_num] + input_subs_list[op_num + 1:]
-        new_subscripts = ','.join([output_subs] + rest_of_subs) + '->' + subs_wrt
-        return unbroadcast_einsum(vs, gvs, anp.einsum(new_subscripts, *((g,) + rest_of_ops)),
-                                  subs_wrt)
-    else:  # Using (op0, sublist0, op1, sublist1..., sublistout) convention.
+        subs_wrt = in_subs_list[op_num]
+        rest_of_ops = operands[:op_num] + operands[op_num+1:]
+        rest_of_subs = in_subs_list[:op_num] + in_subs_list[op_num+1:]
+
+        # subscripts that only appear in subs_wrt (and not in other subscript lists
+        # or in the output) are implicitly being summed out, as if contracted
+        # against a tensor of ones. we make that tensor of ones explicit to handle
+        # the necessary vjp broadcasting inside einsum.
+        other_named_subs = set(''.join([out_subs] + rest_of_subs))
+        naked_summed = [(i, sub) for (i, sub) in enumerate(subs_wrt)
+                        if sub not in other_named_subs]
+        if naked_summed:
+            naked_summed_dims, ones_subs = zip(*naked_summed)
+            ones_subs = ''.join(ones_subs)
+            ones = onp.ones(onp.array(operands[op_num].shape)[naked_summed_dims])
+            new_input_subs = ','.join([out_subs, ones_subs] + rest_of_subs)
+            new_operands = (g, ones) + rest_of_ops
+        else:
+            new_input_subs = ','.join([out_subs] + rest_of_subs)
+            new_operands = (g,) + rest_of_ops
+
+        new_subscripts = new_input_subs + '->' + subs_wrt
+        return anp.einsum(new_subscripts, *new_operands)
+    else:  # using (op0, sublist0, op1, sublist1, ..., sublistout) convention
         if len(operands) % 2 == 0:
             raise NotImplementedError("Need sublistout argument")
         operands = list(operands)
-        rest_of_ops = [operands[-1]] + operands[:argnum] + operands[(argnum+2):-1] + [operands[argnum+1]]
+        rest_of_ops = [operands[-1]] + operands[:argnum] + \
+                operands[(argnum+2):-1] + [operands[argnum+1]]
         return unbroadcast_einsum(vs, gvs, anp.einsum(g, *rest_of_ops), operands[argnum + 1])
-
 anp.einsum.vjp = grad_einsum
 
 @primitive

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup
 
 setup(
     name='autograd',
-    version='1.1.9',
+    version='1.1.10',
     description='Efficiently computes derivatives of numpy code.',
     author='Dougal Maclaurin and David Duvenaud and Matthew Johnson',
     author_email="maclaurin@physics.harvard.edu, duvenaud@cs.toronto.edu, mattjj@csail.mit.edu",
     packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats'],
-    install_requires=['numpy>=1.10', 'scipy>=0.17', 'future>=0.15.2'],
+    install_requires=['numpy>=1.12.1', 'scipy>=0.17', 'future>=0.15.2'],
     keywords=['Automatic differentiation', 'backpropagation', 'gradients',
               'machine learning', 'optimization', 'neural networks',
               'Python', 'Numpy', 'Scipy'],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Dougal Maclaurin and David Duvenaud and Matthew Johnson',
     author_email="maclaurin@physics.harvard.edu, duvenaud@cs.toronto.edu, mattjj@csail.mit.edu",
     packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats'],
-    install_requires=['numpy>=1.12.1', 'scipy>=0.17', 'future>=0.15.2'],
+    install_requires=['numpy>=1.12', 'scipy>=0.17', 'future>=0.15.2'],
     keywords=['Automatic differentiation', 'backpropagation', 'gradients',
               'machine learning', 'optimization', 'neural networks',
               'Python', 'Numpy', 'Scipy'],

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -184,6 +184,7 @@ def test_einsum2_three_args(): combo_check(np.einsum, [0, 2],
 def test_einsum_naked_sum(): combo_check(np.einsum, [1, 2], ['k,nk->'], [R(5)], [R(10, 5)])
 def test_einsum_naked_sum_ellipsis(): combo_check(np.einsum, [1, 2], ['...k,...nk->...'],
                                                   [R(3, 5)], [R(3, 10, 5)])
+def test_einsum_no_output_indices(): combo_check(np.einsum, [1, 2], ['ij,k'], [R(3,4)], [R(3)])
 
 def test_trace():    combo_check(np.trace, [0], [R(5, 5), R(4, 5), R(5, 4), R(3, 4, 5)], offset=[-1, 0, 1])
 def test_diag():     combo_check(np.diag, [0], [R(5, 5)], k=[-1, 0, 1])

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -159,6 +159,8 @@ def test_einsum_matmult():    combo_check(np.einsum, [1, 2], ['ij,jk->ik'], [R(2
 def test_einsum_matmult_broadcast(): combo_check(np.einsum, [1, 2], ['...ij,...jk->...ik'],
                                                  [R(2, 3), R(2, 2, 3)],
                                                  [R(3, 4), R(2, 3, 4)])
+def test_einsum_matmult_broadcast_leadzero(): combo_check(np.einsum, [1, 2], ['...ij,...jk->...ik'],
+                                                          [R(0, 2, 3)], [R(0, 3, 4)])
 def test_einsum_covsum():     combo_check(np.einsum, [1, 2], ['ijk,lji->lki'], [R(3, 4, 4)], [R(4, 4, 3)])
 def test_einsum_ellipses(): combo_check(np.einsum, [1, 2], ['...jk,...lj->...lk', '...,...->...'],
                                         [R(4, 4), R(3, 4, 4)],

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -181,6 +181,9 @@ def test_einsum2_matmult_broadcast(): combo_check(np.einsum, [0, 2],
 def test_einsum2_covsum():     combo_check(np.einsum, [0, 2], [R(3, 4, 4)], [(0,1,2)], [R(4, 4, 3)], [(3,1,0)], [(3,2,0)])
 def test_einsum2_three_args(): combo_check(np.einsum, [0, 2],
                                           [R(3, 4, 4)], [(0,1,2)], [R(4, 4, 3)], [(3,1,0)], [R(4, 4, 3)], [(3,3,0)], [(3,2,0)])
+def test_einsum_naked_sum(): combo_check(np.einsum, [1, 2], ['k,nk->'], [R(5)], [R(10, 5)])
+def test_einsum_naked_sum_ellipsis(): combo_check(np.einsum, [1, 2], ['...k,...nk->...'],
+                                                  [R(3, 5)], [R(3, 10, 5)])
 
 def test_trace():    combo_check(np.trace, [0], [R(5, 5), R(4, 5), R(5, 4), R(3, 4, 5)], offset=[-1, 0, 1])
 def test_diag():     combo_check(np.diag, [0], [R(5, 5)], k=[-1, 0, 1])


### PR DESCRIPTION
Our current `grad_einsum` implementation relies on some manual string parsing, which doesn't handle all cases (e.g. `np.einsum('k,nk->', randn(2), randn(3,2))` caused an einsum subscript error, and `np.einsum('ij,k', randn(2, 3), randn(4))` caused a NotImplementedError).

This PR replaces that manual string parsing with a call to the new `_parse_einsum_input` function in numpy 1.12, simplifying and generalizing `grad_einsum` at the cost of bumping the numpy version requirement and relying on an internal numpy function. We could instead get the same function from the [opt_einsum module](https://github.com/dgasmith/opt_einsum), or we could copy its source into autograd (if the licenses allow) since it's short and self-contained.

Now we don't even need to call `unbroadcast_einsum` when using the "ijk" convention! With this PR, one `einsum` call in the forward pass turns into one `einsum` call in the backward pass, avoiding any graph expansion (which we'd like to avoid for linear ops!).