### PR TITLE
Add Python 3.6 to travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 notifications:
   email: false
 before_install:
@@ -15,6 +16,7 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda update --yes conda
+  - conda config --add channels conda-forge
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy nose future
   - pip install -v .


### PR DESCRIPTION
Also switch default package source to the open source 'conda-forge' channel, which fixes the testing issue with [https://github.com/HIPS/autograd/pull/213](https://github.com/HIPS/autograd/pull/213).