### PR TITLE
backward_pass now clears nodes which will not be used

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -40,6 +40,7 @@ def backward_pass(g, end_node, start_node):
                                    parent.vspace, node.vspace, args, kwargs)
             outgrads[parent].append(outgrad)
             assert_vspace_match(outgrad, parent.vspace, function)
+    	outgrads[node] = None
     return cur_outgrad
 
 active_progenitors = set()

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -40,7 +40,7 @@ def backward_pass(g, end_node, start_node):
                                    parent.vspace, node.vspace, args, kwargs)
             outgrads[parent].append(outgrad)
             assert_vspace_match(outgrad, parent.vspace, function)
-        outgrads[node] = None
+        del outgrads[node]
     return cur_outgrad
 
 active_progenitors = set()

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -40,7 +40,7 @@ def backward_pass(g, end_node, start_node):
                                    parent.vspace, node.vspace, args, kwargs)
             outgrads[parent].append(outgrad)
             assert_vspace_match(outgrad, parent.vspace, function)
-    	outgrads[node] = None
+        outgrads[node] = None
     return cur_outgrad
 
 active_progenitors = set()


### PR DESCRIPTION
Attempting to help issues mentioned in https://github.com/HIPS/autograd/issues/219

This line removed any references to Array nodes which will not be revisited, since they have passed all their gradient information to their parents.

In the special case of the start_node, the gradients will not be lost, since setting outgrads[node] to None only deletes the reference, not the values. So as long as cur_outgrad holds on to the gradient reference all is fine.

On a test dataset, using a proprietary algorithm which can be roughly described as two RNN's feeding into eachother, I obtained the following gains in performance.

https://cloud.githubusercontent.com/assets/6620250/25814415/6a8f085a-33eb-11e7-9237-ce58fa09300a.png

In addition, I compared the numerical results of my change to the previous version, and they were identical.