### PR TITLE
Another small correction to vae example

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -29,7 +29,7 @@ def bernoulli_log_density(targets, unnormalized_logprobs):
     return np.sum(label_probabilities, axis=-1)   # Sum across pixels.
 
 def relu(x):    return np.maximum(0, x)
-def sigmoid(x): return 0.5 * (np.tanh(x) + 1)
+def sigmoid(x): return 0.5 * (np.tanh(0.5 * x) + 1)
 
 def init_net_params(scale, layer_sizes, rs=npr.RandomState(0)):
     """Build a (weights, biases) tuples for all layers."""


### PR DESCRIPTION
The 'unnormalised probability' is (I think) the log-odds or logit

x = log(p / (1 -  p) )

To recover p I think we need

p = 1/(1 + e^{-x})
  &nbsp;&nbsp;&nbsp;= 0.5 * (tanh(0.5 * x) + 1).

Note that both of these functions are included as ufuncs in scipy.special: [logit](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.logit.html#scipy.special.logit), [sigmoid (AKA expit)](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.expit.html#scipy.special.expit). So maybe at some point we should implement their gradients and start using them as primitives.