### PR TITLE
Simplify util.flatten

### DIFF
--- a/autograd/container_types.py
+++ b/autograd/container_types.py
@@ -4,7 +4,7 @@ from autograd.core import (primitive, Node, VSpace, register_node, vspace,
 from builtins import zip
 from future.utils import iteritems
 from functools import partial
-import numpy as np
+import autograd.numpy as np
 
 class SequenceNode(Node):
     __slots__ = []

--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -78,7 +78,7 @@ class ArrayVSpace(VSpace):
         return anp.zeros(self.shape, dtype=self.dtype)
 
     def flatten(self, value, covector=False):
-        return np.ravel(value)
+        return anp.ravel(value)
 
     def unflatten(self, value, covector=False):
         return value.reshape(self.shape)
@@ -102,16 +102,16 @@ class ComplexArrayVSpace(ArrayVSpace):
 
     def flatten(self, value, covector=False):
         if covector:
-            return np.ravel(np.stack([np.real(value), - np.imag(value)]))
+            return anp.ravel(anp.stack([anp.real(value), - anp.imag(value)]))
         else:
-            return np.ravel(np.stack([np.real(value), np.imag(value)]))
+            return anp.ravel(anp.stack([anp.real(value), anp.imag(value)]))
 
     def unflatten(self, value, covector=False):
-        reshaped = np.reshape(value, (2,) + self.shape)
+        reshaped = anp.reshape(value, (2,) + self.shape)
         if covector:
-            return np.array(reshaped[0] - 1j * reshaped[1])
+            return anp.array(reshaped[0] - 1j * reshaped[1])
         else:
-            return np.array(reshaped[0] + 1j * reshaped[1])
+            return anp.array(reshaped[0] + 1j * reshaped[1])
 
 register_node(ArrayNode, np.ndarray)
 register_vspace(lambda x: ComplexArrayVSpace(x)

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -95,43 +95,11 @@ def flatten(value):
        Returns 1D numpy array and an unflatten function.
        Doesn't preserve mixed numeric types (e.g. floats and ints).
        Assumes dict keys are sortable."""
-    if isinstance(getval(value), np.ndarray):
-        shape = value.shape
-        def unflatten(vector):
-            return np.reshape(vector, shape)
-        return np.ravel(value), unflatten
-
-    elif isinstance(getval(value), (float, int)):
-        return np.array([value]), lambda x : x[0]
-
-    elif isinstance(getval(value), (tuple, list)):
-        constructor = make_tuple if isinstance(getval(value), tuple) else make_list
-        if not value:
-            return np.array([]), lambda x : constructor()
-        flat_pieces, unflatteners = zip(*map(flatten, value))
-        split_indices = np.cumsum([len(vec) for vec in flat_pieces[:-1]])
-
-        def unflatten(vector):
-            pieces = np.split(vector, split_indices)
-            return constructor(*[unflatten(v) for unflatten, v in zip(unflatteners, pieces)])
-
-        return np.concatenate(flat_pieces), unflatten
-
-    elif isinstance(getval(value), dict):
-        items = sorted(iteritems(value), key=itemgetter(0))
-        keys, flat_pieces, unflatteners = zip(*[(k,) + flatten(v) for k, v in items])
-        split_indices = np.cumsum([len(vec) for vec in flat_pieces[:-1]])
-
-        def unflatten(vector):
-            pieces = np.split(vector, split_indices)
-            return make_dict([(key, unflattener(piece))
-                    for piece, unflattener, key in zip(pieces, unflatteners, keys)])
-
-        return np.concatenate(flat_pieces), unflatten
-
-    else:
+    try:
+        vs = vspace(getval(value))
+    except TypeError:
         raise Exception("Don't know how to flatten type {}".format(type(value)))
-
+    return vs.flatten(value), vs.unflatten
 
 def flatten_func(func, example):
     """Flattens both the inputs to a function, and the outputs."""

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -3,6 +3,9 @@
 # http://asv.readthedocs.io/en/latest/writing_benchmarks.html
 from autograd import grad
 import autograd.numpy as np
+import autograd.numpy.random as npr
+from autograd.util import flatten
+from autograd.core import vspace_flatten
 
 class RNNSuite:
     """
@@ -164,3 +167,40 @@ class RNNSuite:
             return g_W, g_b, g_Wout, g_bout
         _rnn_grad(self.x, self.W1,self.b1,self.Wout,self.bout,self.l,self.n)
         pass
+
+def time_flatten():
+    val = {'k':  npr.random((4, 4)),
+           'k2': npr.random((3, 3)),
+           'k3': 3.0,
+           'k4': [1.0, 4.0, 7.0, 9.0],
+           'k5': np.array([4., 5., 6.]),
+           'k6': np.array([[7., 8.], [9., 10.]])}
+
+    vect, unflatten = flatten(val)
+    val_recovered = unflatten(vect)
+    vect_2, _ = flatten(val_recovered)
+
+def time_vspace_flatten():
+    val = {'k':  npr.random((4, 4)),
+           'k2': npr.random((3, 3)),
+           'k3': 3.0,
+           'k4': [1.0, 4.0, 7.0, 9.0],
+           'k5': np.array([4., 5., 6.]),
+           'k6': np.array([[7., 8.], [9., 10.]])}
+
+    vspace_flatten(val)
+
+def time_grad_flatten():
+    val = {'k':  npr.random((4, 4)),
+           'k2': npr.random((3, 3)),
+           'k3': 3.0,
+           'k4': [1.0, 4.0, 7.0, 9.0],
+           'k5': np.array([4., 5., 6.]),
+           'k6': np.array([[7., 8.], [9., 10.]])}
+
+    vect, unflatten = flatten(val)
+    def fun(vec):
+        v = unflatten(vec)
+        return np.sum(v['k5']) + np.sum(v['k6'])
+
+    grad(fun)(vect)


### PR DESCRIPTION
Use the vspace flatten functionality for util.flatten. This enables flattening of complex values which wasn't previously possible.

Am I missing some reason why this isn't ok? The only difference in functionality which I can see is that with this change, calling `flatten` on scalars will give an `unflatten` which returns scalar values _wrapped in an array_. In particular:

**On master**
```python
In [1]: from autograd.util import flatten

In [2]: v, unflatten = flatten(3.)

In [3]: v
Out[3]: array([ 3.])

In [4]: unflatten(v)
Out[4]: 3.0
```

**With this change:**
```python
In [1]: from autograd.util import flatten

In [2]: v, unflatten = flatten(3.)

In [3]: v
Out[3]: array([ 3.])

In [4]: unflatten(v)
Out[4]: array(3.0)
```
Is this a big deal? This type of behaviour occurs in other situations where vspace is applied to scalars, for example:
```python
In [7]: from autograd import grad

In [8]: def f(x):
   ...:     return 3.
   ...:

In [9]: grad(f)(2.)
/Users/jamietownsend/dev/autograd/autograd/core.py:16: UserWarning: Output seems independent of input.
  warnings.warn("Output seems independent of input.")
Out[9]: array(0.0)
```
and I don't think that's really a problem.