### PR TITLE
vspace ones and standard_basis methods

### DIFF
--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -17,16 +17,12 @@ def grad(fun, argnum=0):
     positional argument number `argnum`. The returned function takes the same
     arguments as `fun`, but returns the gradient instead. The function `fun`
     should be scalar-valued. The gradient has the same type as the argument."""
-
-    def scalar_fun(*args, **kwargs):
-        return as_scalar(fun(*args, **kwargs))
-
     @attach_name_and_doc(fun, argnum, 'Gradient')
     @add_error_hints
     def gradfun(*args,**kwargs):
         args = list(args)
         args[argnum] = safe_type(args[argnum])
-        vjp, ans = make_vjp(scalar_fun, argnum)(*args, **kwargs)
+        vjp, ans = make_vjp(fun, argnum)(*args, **kwargs)
         return vjp(vspace(getval(ans)).ones())
 
     return gradfun
@@ -219,20 +215,6 @@ def safe_type(value):
         return float(value)
     else:
         return value
-
-def as_scalar(x):
-    vs = vspace(getval(x))
-    if vs.iscomplex:
-        x = np.real(x)
-    if vs.shape == ():
-        return x
-    elif vs.size == 1:
-        return x.reshape(())
-    else:
-        raise TypeError(
-            "Output {} can't be cast to float. "
-            "Function grad requires a scalar-valued function. "
-            "Try jacobian or elementwise_grad.".format(getval(x)))
 
 def cast_to_same_dtype(value, example):
     if hasattr(example, 'dtype') and example.dtype.type is not np.float64:

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import
 from functools import partial
 import autograd.numpy as np
-from autograd.core import (make_vjp, getval, isnode, vspace, get_vspace,
-                           primitive, unbox_if_possible)
+from autograd.core import (make_vjp, getval, isnode, vspace, primitive,
+                           unbox_if_possible)
 from autograd.container_types import make_tuple
 from .errors import add_error_hints
 from collections import OrderedDict

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -199,6 +199,12 @@ class VSpace(object):
     def zeros(self):
         assert False
 
+    def ones(self):
+        assert False
+
+    def standard_basis(self):
+        assert False
+
     def mut_add(self, x, y):
         x += y
         return x
@@ -243,6 +249,8 @@ def vspace(value):
         return vspace_mappings[type(value)](value)
     except KeyError:
         raise TypeError("Can't find vspace for type {}".format(type(value)))
+
+def get_vspace(value_or_node): return vspace(getval(value_or_node))
 
 class SparseObject(object):
     __slots__ = ['vs', 'mut_add']

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -250,8 +250,6 @@ def vspace(value):
     except KeyError:
         raise TypeError("Can't find vspace for type {}".format(type(value)))
 
-def get_vspace(value_or_node): return vspace(getval(value_or_node))
-
 class SparseObject(object):
     __slots__ = ['vs', 'mut_add']
     def __init__(self, vs, mut_add):

--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -75,7 +75,16 @@ class ArrayVSpace(VSpace):
         self.scalartype = float
 
     def zeros(self):
-        return anp.zeros(self.shape, dtype=self.dtype)
+        return np.zeros(self.shape, dtype=self.dtype)
+
+    def ones(self):
+        return np.ones(self.shape, dtype=self.dtype)
+
+    def standard_basis(self):
+      for idxs in np.ndindex(*self.shape):
+            vect = np.zeros(self.shape)
+            vect[idxs] = 1
+            yield vect
 
     def flatten(self, value, covector=False):
         return anp.ravel(value)

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -8,14 +8,14 @@ npr.seed(1)
 def test_real_type():
     fun = lambda x: np.sum(np.real(x))
     df = grad(fun)
-    assert type(df(1.0)) == float
-    assert type(df(1.0j)) == complex
+    assert np.isrealobj(df(2.0))
+    assert np.iscomplexobj(df(1.0j))
 
 def test_real_if_close_type():
     fun = lambda x: np.sum(np.real(x))
     df = grad(fun)
-    assert type(df(1.0)) == float
-    assert type(df(1.0j)) == complex
+    assert np.isrealobj(df(1.0))
+    assert np.iscomplexobj(df(1.0j))
 
 def test_angle_real():
     fun = lambda x : to_scalar(np.angle(x))

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -161,13 +161,13 @@ def test_assignment_raises_error():
     A = npr.randn(5)
     check_grads(fun, A, 3.0)
 
-@raises(TypeError)
-def test_nonscalar_output_1():
-    grad(lambda x: x * 2)(np.zeros(2))
+# @raises(TypeError)
+# def test_nonscalar_output_1():
+#     grad(lambda x: x * 2)(np.zeros(2))
 
-@raises(TypeError)
-def test_nonscalar_output_2():
-    grad(lambda x: x * 2)(np.zeros(2))
+# @raises(TypeError)
+# def test_nonscalar_output_2():
+#     grad(lambda x: x * 2)(np.zeros(2))
 
 # TODO:
 # Diamond patterns


### PR DESCRIPTION
Add `vspace.ones()` and `vspace.standard_basis()`, for use in `grad` and `jacobian` to reduce the dependence of core.py on numpy, and also to simplify the code.

This PR also currently includes a change in the behavior of `grad` on non-scalar-valued functions. In master, when `grad` is applied to non-scalar-valued functions, it raises an error. To get broadcasting support, we use a separate function `elementwise_grad`. The change in behavior here is that `grad` now acts like `elementwise_grad` on non-scalar-valued functions, instead of raising an error. I think the error raising behavior would be easy to restore by adding a check on the output vspace, but this change seems worth considering.