### PR TITLE
Add make_jvp and make_ggnvp convenience wrappers

### DIFF
--- a/autograd/__init__.py
+++ b/autograd/__init__.py
@@ -3,6 +3,8 @@ from .core import primitive, make_vjp, getval
 from . import container_types
 from .container_types import make_tuple, make_list, make_dict
 from .convenience_wrappers import (grad, multigrad, multigrad_dict, elementwise_grad,
-                                   value_and_grad, grad_and_aux, hessian_vector_product,
-                                   hessian, jacobian, vector_jacobian_product, grad_named,
-                                   checkpoint, make_hvp, value_and_multigrad)
+                                   value_and_grad, grad_and_aux, hessian_tensor_product,
+                                   hessian_vector_product, hessian, jacobian,
+                                   tensor_jacobian_product, vector_jacobian_product,
+                                   grad_named, checkpoint, make_hvp, value_and_multigrad,
+                                   make_jvp, make_ggnvp)


### PR DESCRIPTION
This PR adds the `make_jvp` and `make_ggnvp` convenience wrappers we developed in the thread for #175, plus tests. (It also adjusts the names inside make_vjp to be more consistent with vjp usage elsewhere.)

There are some wasted FLOPs in these implementations where we propagate zero vectors through vjp's just to trace them; I think we could get rid of these wasteful computations by adding a new function to core.py that essentially transposes the matrix-free linear map represented by calling `backward_pass` on a trace. However, there would still be graph munging overhead compared to a proper forward-mode implementation.