### PR TITLE
change readme not to use elementwise_grad, since grad now broadcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,19 @@ Example use:
 0.39322386636453377
 ```
 
-We can continue to differentiate as many times as we like:
+We can continue to differentiate as many times as we like, and use numpy's
+broadcasting of scalar-valued functions across many different input values:
 
 ```python
->>> def elementwise_grad(fun):                   # A wrapper for broadcasting
-...     return grad(lambda x: np.sum(fun(x)))    # (closures are no problem)
-...
->>> grad_tanh   = elementwise_grad(tanh)
->>> grad_tanh_2 = elementwise_grad(grad_tanh)    # 2nd derivative
->>> grad_tanh_3 = elementwise_grad(grad_tanh_2)  # 3rd derivative
->>> grad_tanh_4 = elementwise_grad(grad_tanh_3)  # etc.
->>> grad_tanh_5 = elementwise_grad(grad_tanh_4)
->>> grad_tanh_6 = elementwise_grad(grad_tanh_5)
+>>> grad_tanh   = grad(tanh)
+>>> grad_tanh_2 = grad(grad_tanh)    # 2nd derivative
+>>> grad_tanh_3 = grad(grad_tanh_2)  # 3rd derivative
+>>> grad_tanh_4 = grad(grad_tanh_3)  # etc.
+>>> grad_tanh_5 = grad(grad_tanh_4)
+>>> grad_tanh_6 = grad(grad_tanh_5)
 >>>
 >>> import matplotlib.pyplot as plt
->>> x = np.linspace(-7, 7, 200)
+>>> x = np.linspace(-7, 7, 200)  # grad handles broadcasting across inputs
 >>> plt.plot(x, tanh(x),
 ...          x, grad_tanh(x),
 ...          x, grad_tanh_2(x),

--- a/examples/tanh.py
+++ b/examples/tanh.py
@@ -1,20 +1,31 @@
 from __future__ import absolute_import
 import autograd.numpy as np
 import matplotlib.pyplot as plt
-from autograd import elementwise_grad
+from autograd import grad
 
-# Here we use elementwise_grad to support broadcasting, which makes evaluating
-# the gradient functions faster and avoids the need for calling 'map'.
+'''
+Mathematically we can only take gradients of scalar-valued functions, but
+autograd's grad function also handles numpy's familiar broadcasting behavior,
+which is used in this example.
+
+To be precise, grad(fun)(x) always returns the value of a vector-Jacobian
+product, where the Jacobian of fun is evaluated at x and the the vector is an
+all-ones vector with the same size as the output of fun. When broadcasting a
+scalar-valued function over many arguments, the Jacobian of the overall
+vector-to-vector mapping is diagonal, and so this vector-Jacobian product simply
+returns the diagonal elements of the Jacobian, which is the gradient of the
+function at each broadcasted input value.
+'''
 
 def tanh(x):
     return (1.0 - np.exp(-x))  / (1.0 + np.exp(-x))
 
-d_fun      = elementwise_grad(tanh)       # First derivative
-dd_fun     = elementwise_grad(d_fun)      # Second derivative
-ddd_fun    = elementwise_grad(dd_fun)     # Third derivative
-dddd_fun   = elementwise_grad(ddd_fun)    # Fourth derivative
-ddddd_fun  = elementwise_grad(dddd_fun)   # Fifth derivative
-dddddd_fun = elementwise_grad(ddddd_fun)  # Sixth derivative
+d_fun      = grad(tanh)       # First derivative
+dd_fun     = grad(d_fun)      # Second derivative
+ddd_fun    = grad(dd_fun)     # Third derivative
+dddd_fun   = grad(ddd_fun)    # Fourth derivative
+ddddd_fun  = grad(dddd_fun)   # Fifth derivative
+dddddd_fun = grad(ddddd_fun)  # Sixth derivative
 
 x = np.linspace(-7, 7, 200)
 plt.plot(x, tanh(x),


### PR DESCRIPTION
We recently changed `grad` to handle broadcasting automatically. This PR updates README.md accordingly, and also changes examples/tanh.py to explain this behavior in a bit more detail.