### PR TITLE
fixed reshape bug in maxpool layer of convnet example

### DIFF
--- a/examples/convnet.py
+++ b/examples/convnet.py
@@ -110,9 +110,9 @@ class maxpool_layer(object):
         for i in [0, 1]:
             pool_width = self.pool_shape[i]
             img_width = inputs.shape[i + 2]
-            new_shape += (pool_width, img_width // pool_width)
+            new_shape += (img_width // pool_width, pool_width)
         result = inputs.reshape(new_shape)
-        return np.max(np.max(result, axis=2), axis=3)
+        return np.max(np.max(result, axis=3), axis=4)
 
 class full_layer(object):
     def __init__(self, size):


### PR DESCRIPTION
The previous code for the max pool layer was implemented along the wrong directions.  Even though the global shape of the resulting array was correct, its content was completely off.  This can easily be seen by looking at some plots of before and after the max pool layer.

This pull request fixed this bug so that the max pool layer is now correctly implemented.