### PR TITLE
Flexible vspace function and simplify flatten, reverting #248

### DIFF
--- a/autograd/container_types.py
+++ b/autograd/container_types.py
@@ -4,7 +4,7 @@ from autograd.core import (primitive, Node, VSpace, register_node, vspace,
 from builtins import zip
 from future.utils import iteritems
 from functools import partial
-import numpy as np
+import autograd.numpy as np
 
 class SequenceNode(Node):
     __slots__ = []

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -250,7 +250,10 @@ def vspace(value):
     try:
         return vspace_mappings[type(value)](value)
     except KeyError:
-        raise TypeError("Can't find vspace for type {}".format(type(value)))
+        if isnode(value):
+            return value.vspace
+        else:
+            raise TypeError("Can't find vspace for type {}".format(type(value)))
 
 class SparseObject(object):
     __slots__ = ['vs', 'mut_add']

--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -86,7 +86,7 @@ class ArrayVSpace(VSpace):
             yield vect
 
     def flatten(self, value, covector=False):
-        return np.ravel(value)
+        return anp.ravel(value)
 
     def unflatten(self, value, covector=False):
         return value.reshape(self.shape)
@@ -110,16 +110,16 @@ class ComplexArrayVSpace(ArrayVSpace):
 
     def flatten(self, value, covector=False):
         if covector:
-            return np.ravel(np.stack([np.real(value), - np.imag(value)]))
+            return anp.ravel(anp.stack([anp.real(value), - anp.imag(value)]))
         else:
-            return np.ravel(np.stack([np.real(value), np.imag(value)]))
+            return anp.ravel(anp.stack([anp.real(value), anp.imag(value)]))
 
     def unflatten(self, value, covector=False):
-        reshaped = np.reshape(value, (2,) + self.shape)
+        reshaped = anp.reshape(value, (2,) + self.shape)
         if covector:
-            return np.array(reshaped[0] - 1j * reshaped[1])
+            return anp.array(reshaped[0] - 1j * reshaped[1])
         else:
-            return np.array(reshaped[0] + 1j * reshaped[1])
+            return anp.array(reshaped[0] + 1j * reshaped[1])
 
 register_node(ArrayNode, np.ndarray)
 register_vspace(lambda x: ComplexArrayVSpace(x)

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -1,14 +1,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from copy import copy
-from operator import itemgetter
-from future.utils import iteritems
-from builtins import map, range, zip
+from builtins import range
 
 import autograd.numpy as np
 from autograd.convenience_wrappers import grad
 from autograd.core import vspace, vspace_flatten, getval
-from autograd.container_types import make_tuple, make_list, make_dict
 
 EPS, RTOL, ATOL = 1e-4, 1e-4, 1e-6
 

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -92,39 +92,8 @@ def flatten(value):
        Returns 1D numpy array and an unflatten function.
        Doesn't preserve mixed numeric types (e.g. floats and ints).
        Assumes dict keys are sortable."""
-    if isinstance(getval(value), np.ndarray):
-        shape = value.shape
-        def unflatten(vector):
-            return np.reshape(vector, shape)
-        return np.ravel(value), unflatten
-
-    elif isinstance(getval(value), (float, int)):
-        return np.array([value]), lambda x : x[0]
-
-    elif isinstance(getval(value), (tuple, list)):
-        constructor = make_tuple if isinstance(getval(value), tuple) else make_list
-        if not value:
-            return np.array([]), lambda x : constructor()
-        flat_pieces, unflatteners = zip(*map(flatten, value))
-        split_indices = np.cumsum([len(vec) for vec in flat_pieces[:-1]])
-
-        def unflatten(vector):
-            pieces = np.split(vector, split_indices)
-            return constructor(*[unflatten(v) for unflatten, v in zip(unflatteners, pieces)])
-
-        return np.concatenate(flat_pieces), unflatten
-
-    elif isinstance(getval(value), dict):
-        items = sorted(iteritems(value), key=itemgetter(0))
-        keys, flat_pieces, unflatteners = zip(*[(k,) + flatten(v) for k, v in items])
-        split_indices = np.cumsum([len(vec) for vec in flat_pieces[:-1]])
-
-        def unflatten(vector):
-            pieces = np.split(vector, split_indices)
-            return make_dict([(key, unflattener(piece))
-                    for piece, unflattener, key in zip(pieces, unflatteners, keys)])
-
-        return np.concatenate(flat_pieces), unflatten
+    vs = vspace(value)
+    return vs.flatten(value), vs.unflatten
 
 def flatten_func(func, example):
     """Flattens both the inputs to a function, and the outputs."""

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -34,3 +34,8 @@ def test_flatten_nodes_in_containers():
         xy, _ = flatten([x, y])
         return np.sum(xy)
     grad(f)(1.0, 2.0)
+
+def test_flatten_complex():
+    val = 1 + 1j
+    flat, unflatten = flatten(val)
+    assert np.all(val == unflatten(flat))


### PR DESCRIPTION
The `vspace` function has been adapted to work on `Node` types. This was discussed in https://github.com/HIPS/autograd/pull/232. I've also simplified flatten again and added a test for flattening Python complex numbers (functionality which is handy for autograd-forward testing).

@mattjj's new test is still there and is passing on this branch.