### PR TITLE
Remove getval from vspace(getval(...)) pattern (depends on #260)

### DIFF
--- a/autograd/container_types.py
+++ b/autograd/container_types.py
@@ -4,7 +4,7 @@ from autograd.core import (primitive, Node, VSpace, register_node, vspace,
 from builtins import zip
 from future.utils import iteritems
 from functools import partial
-import numpy as np
+import autograd.numpy as np
 
 class SequenceNode(Node):
     __slots__ = []

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -1,8 +1,7 @@
 """Convenience functions built on top of `make_vjp`."""
 from __future__ import absolute_import
 import autograd.numpy as np
-from autograd.core import (make_vjp, getval, vspace, primitive,
-                           unbox_if_possible)
+from autograd.core import make_vjp, vspace, primitive, unbox_if_possible
 from autograd.container_types import make_tuple
 from .errors import add_error_hints
 from collections import OrderedDict

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -21,7 +21,7 @@ def grad(fun, argnum=0):
         args = list(args)
         args[argnum] = safe_type(args[argnum])
         vjp, ans = make_vjp(fun, argnum)(*args, **kwargs)
-        return vjp(vspace(getval(ans)).ones())
+        return vjp(vspace(ans).ones())
 
     return gradfun
 
@@ -38,8 +38,8 @@ def jacobian(fun, argnum=0):
     @add_error_hints
     def jacfun(*args, **kwargs):
         vjp, ans = make_vjp(fun, argnum)(*args, **kwargs)
-        ans_vspace = vspace(getval(ans))
-        jacobian_shape = ans_vspace.shape + vspace(getval(args[argnum])).shape
+        ans_vspace = vspace(ans)
+        jacobian_shape = ans_vspace.shape + vspace(args[argnum]).shape
         grads = map(vjp, ans_vspace.standard_basis())
         return np.reshape(np.stack(grads), jacobian_shape)
 
@@ -115,7 +115,7 @@ def make_jvp(fun, argnum=0):
     well as other overheads. See github.com/BB-UCL/autograd-forward."""
     def jvp_maker(*args, **kwargs):
         vjp, y = make_vjp(fun, argnum)(*args, **kwargs)
-        vjp_vjp, _ = make_vjp(vjp)(vspace(getval(y)).zeros())
+        vjp_vjp, _ = make_vjp(vjp)(vspace(y).zeros())
         return vjp_vjp  # vjp_vjp is just jvp by linearity
     return jvp_maker
 
@@ -125,7 +125,7 @@ def make_ggnvp(f, g=lambda x: 1./2*np.sum(x**2, axis=-1), f_argnum=0):
     def ggnvp_maker(*args, **kwargs):
         f_vjp, f_x = make_vjp(f, f_argnum)(*args, **kwargs)
         g_hvp, grad_g_x = make_vjp(grad(g))(f_x)
-        f_vjp_vjp, _ = make_vjp(f_vjp)(vspace(getval(grad_g_x)).zeros())
+        f_vjp_vjp, _ = make_vjp(f_vjp)(vspace(grad_g_x).zeros())
         def ggnvp(v): return f_vjp(g_hvp(f_vjp_vjp(v)))
         return ggnvp
     return ggnvp_maker

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -250,7 +250,10 @@ def vspace(value):
     try:
         return vspace_mappings[type(value)](value)
     except KeyError:
-        raise TypeError("Can't find vspace for type {}".format(type(value)))
+        if isnode(value):
+            return value.vspace
+        else:
+            raise TypeError("Can't find vspace for type {}".format(type(value)))
 
 class SparseObject(object):
     __slots__ = ['vs', 'mut_add']

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -265,10 +265,10 @@ register_vspace(lambda x : x.vs, SparseObject)
 register_node(Node, SparseObject)
 
 def assert_vspace_match(x, expected_vspace, fun):
-    assert expected_vspace == vspace(getval(x)), \
+    assert expected_vspace == vspace(x), \
         "\nGrad of {} returned unexpected vector space" \
         "\nVector space is {}" \
-        "\nExpected        {}".format(fun, vspace(getval(x)), expected_vspace)
+        "\nExpected        {}".format(fun, vspace(x), expected_vspace)
 
 isnode = lambda x: type(x) in node_types
 getval = lambda x: x.value if isnode(x) else x

--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -86,7 +86,7 @@ class ArrayVSpace(VSpace):
             yield vect
 
     def flatten(self, value, covector=False):
-        return np.ravel(value)
+        return anp.ravel(value)
 
     def unflatten(self, value, covector=False):
         return value.reshape(self.shape)
@@ -110,16 +110,16 @@ class ComplexArrayVSpace(ArrayVSpace):
 
     def flatten(self, value, covector=False):
         if covector:
-            return np.ravel(np.stack([np.real(value), - np.imag(value)]))
+            return anp.ravel(anp.stack([anp.real(value), - anp.imag(value)]))
         else:
-            return np.ravel(np.stack([np.real(value), np.imag(value)]))
+            return anp.ravel(anp.stack([anp.real(value), anp.imag(value)]))
 
     def unflatten(self, value, covector=False):
-        reshaped = np.reshape(value, (2,) + self.shape)
+        reshaped = anp.reshape(value, (2,) + self.shape)
         if covector:
-            return np.array(reshaped[0] - 1j * reshaped[1])
+            return anp.array(reshaped[0] - 1j * reshaped[1])
         else:
-            return np.array(reshaped[0] + 1j * reshaped[1])
+            return anp.array(reshaped[0] + 1j * reshaped[1])
 
 register_node(ArrayNode, np.ndarray)
 register_vspace(lambda x: ComplexArrayVSpace(x)

--- a/autograd/numpy/numpy_grads.py
+++ b/autograd/numpy/numpy_grads.py
@@ -444,7 +444,7 @@ anp.make_diagonal.defvjp(
     anp.diagonal(g, offset, axis1, axis2))
 
 def match_complex(vs, x):
-    x_iscomplex = vspace(getval(x)).iscomplex
+    x_iscomplex = vspace(x).iscomplex
     if x_iscomplex and not vs.iscomplex:
         return anp.real(x)
     elif not x_iscomplex and vs.iscomplex:

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -1,14 +1,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from copy import copy
-from operator import itemgetter
-from future.utils import iteritems
-from builtins import map, range, zip
+from builtins import range
 
 import autograd.numpy as np
 from autograd.convenience_wrappers import grad
 from autograd.core import vspace, vspace_flatten, getval
-from autograd.container_types import make_tuple, make_list, make_dict
 
 EPS, RTOL, ATOL = 1e-4, 1e-4, 1e-6
 

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -92,39 +92,8 @@ def flatten(value):
        Returns 1D numpy array and an unflatten function.
        Doesn't preserve mixed numeric types (e.g. floats and ints).
        Assumes dict keys are sortable."""
-    if isinstance(getval(value), np.ndarray):
-        shape = value.shape
-        def unflatten(vector):
-            return np.reshape(vector, shape)
-        return np.ravel(value), unflatten
-
-    elif isinstance(getval(value), (float, int)):
-        return np.array([value]), lambda x : x[0]
-
-    elif isinstance(getval(value), (tuple, list)):
-        constructor = make_tuple if isinstance(getval(value), tuple) else make_list
-        if not value:
-            return np.array([]), lambda x : constructor()
-        flat_pieces, unflatteners = zip(*map(flatten, value))
-        split_indices = np.cumsum([len(vec) for vec in flat_pieces[:-1]])
-
-        def unflatten(vector):
-            pieces = np.split(vector, split_indices)
-            return constructor(*[unflatten(v) for unflatten, v in zip(unflatteners, pieces)])
-
-        return np.concatenate(flat_pieces), unflatten
-
-    elif isinstance(getval(value), dict):
-        items = sorted(iteritems(value), key=itemgetter(0))
-        keys, flat_pieces, unflatteners = zip(*[(k,) + flatten(v) for k, v in items])
-        split_indices = np.cumsum([len(vec) for vec in flat_pieces[:-1]])
-
-        def unflatten(vector):
-            pieces = np.split(vector, split_indices)
-            return make_dict([(key, unflattener(piece))
-                    for piece, unflattener, key in zip(pieces, unflatteners, keys)])
-
-        return np.concatenate(flat_pieces), unflatten
+    vs = vspace(value)
+    return vs.flatten(value), vs.unflatten
 
 def flatten_func(func, example):
     """Flattens both the inputs to a function, and the outputs."""

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -34,3 +34,8 @@ def test_flatten_nodes_in_containers():
         xy, _ = flatten([x, y])
         return np.sum(xy)
     grad(f)(1.0, 2.0)
+
+def test_flatten_complex():
+    val = 1 + 1j
+    flat, unflatten = flatten(val)
+    assert np.all(val == unflatten(flat))


### PR DESCRIPTION
This is a code simplification.

Includes an edit to `assert_vspace_match`, which is part of our 'inner loop', however, this doesn't appear to produce any performance regressions.

Benchmarking this branch against master, the only timings to change significantly are those of `flatten`, as expected (this is because of the changes in https://github.com/HIPS/autograd/pull/260, which this branch is based on). There is a slight regression for `vspace_flatten`, which was discussed in https://github.com/HIPS/autograd/pull/260 and is acceptable IMO since this method is only used by the tests.

```
All benchmarks:

    before     after       ratio
  [723e6777] [823c048d]
     1.14μs     1.05μs      0.92  bench_core.time_exp_call
     3.88μs     4.00μs      1.03  bench_core.time_exp_primitive_call_boxed
     3.02μs     3.21μs      1.06  bench_core.time_exp_primitive_call_unboxed
   624.39ms   592.63ms      0.95  bench_core.time_fan_out_fan_in_backward_pass
   229.18ms   230.75ms      1.01  bench_core.time_fan_out_fan_in_forward_pass
   847.61ms   831.57ms      0.98  bench_core.time_fan_out_fan_in_grad
   838.28μs   827.38μs      0.99  bench_core.time_long_backward_pass
   413.39μs   428.94μs      1.04  bench_core.time_long_forward_pass
     1.31ms     1.29ms      0.98  bench_core.time_long_grad
     3.77μs     3.75μs      0.99  bench_core.time_new_node_array
     3.63μs     3.47μs      0.96  bench_core.time_new_node_float
    39.90μs    37.92μs      0.95  bench_core.time_short_backward_pass
    18.08μs    18.29μs      1.01  bench_core.time_short_forward_pass
    90.82μs    87.40μs      0.96  bench_core.time_short_grad
     2.59μs     2.56μs      0.99  bench_core.time_vspace_array
     2.56μs     2.58μs      1.01  bench_core.time_vspace_float
      1.97y      1.96y      1.00  bench_rnn.RNNSuite.peakmem_manual_rnn_grad
      2.09y      2.10y      1.00  bench_rnn.RNNSuite.peakmem_rnn_grad
   609.16ms   617.79ms      1.01  bench_rnn.RNNSuite.time_manual_rnn_grad
   664.51ms   667.79ms      1.00  bench_rnn.RNNSuite.time_rnn_grad
-  290.68μs   211.05μs      0.73  bench_util.time_flatten
-    1.51ms   645.68μs      0.43  bench_util.time_grad_flatten
+   78.13μs   106.64μs      1.36  bench_util.time_vspace_flatten
```