### PR TITLE
Vspace tensor product

### DIFF
--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -38,13 +38,14 @@ def jacobian(fun, argnum=0):
     @add_error_hints
     def jacfun(*args, **kwargs):
         vjp, ans = make_vjp(fun, argnum)(*args, **kwargs)
+        arg_vspace = vspace(getval(args[argnum]))
         ans_vspace = vspace(getval(ans))
         try:
-            jacobian_vspace = ans_vspace * vspace(args[argnum])
+            jacobian_vspace = ans_vspace * arg_vspace
         except NotImplementedError:
             raise ValueError("Input and output must be of scalar or array type, "
                              "with matching dtype.\nInput vspace:\n{} "
-                             "\nOutput vspace:\n{}".format(vspace(args[argnum]), ans_vspace))
+                             "\nOutput vspace:\n{}".format(arg_vspace, ans_vspace))
         grads = map(vjp, ans_vspace.standard_basis())
         return np.reshape(np.stack(grads), jacobian_vspace.shape)
 

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -38,7 +38,7 @@ def jacobian(fun, argnum=0):
     @add_error_hints
     def jacfun(*args, **kwargs):
         vjp, ans = make_vjp(fun, argnum)(*args, **kwargs)
-        ans_vspace = vspace(ans)
+        ans_vspace = vspace(getval(ans))
         try:
             jacobian_vspace = ans_vspace * vspace(args[argnum])
         except NotImplementedError:

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -81,7 +81,7 @@ elementwise_grad = grad  # backward compatibility
 
 def hessian(fun, argnum=0):
     "Returns a function that computes the exact Hessian."
-    return jacobian(grad(fun, argnum), argnum)
+    return jacobian(jacobian(fun, argnum), argnum)
 
 def make_hvp(fun, argnum=0):
     """Builds a function for evaluating the Hessian-vector product at a point,

--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -38,12 +38,13 @@ def jacobian(fun, argnum=0):
     @add_error_hints
     def jacfun(*args, **kwargs):
         vjp, ans = make_vjp(fun, argnum)(*args, **kwargs)
-        ans_vspace = ans.vspace
+        ans_vspace = vspace(ans)
         try:
             jacobian_vspace = ans_vspace * vspace(args[argnum])
         except NotImplementedError:
             raise ValueError("Input and output must be of scalar or array type, "
-                             "with matching dtype.")
+                             "with matching dtype.\nInput vspace:\n{} "
+                             "\nOutput vspace:\n{}".format(vspace(args[argnum]), ans_vspace))
         grads = map(vjp, ans_vspace.standard_basis())
         return np.reshape(np.stack(grads), jacobian_vspace.shape)
 

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -217,6 +217,10 @@ class VSpace(object):
     def __repr__(self):
         return "{}_{}".format(type(self).__name__, self.__dict__)
 
+    def __mul__(self, other):
+        # Tensor product as in https://en.wikipedia.org/wiki/Tensor_product
+        assert False
+
     def examples(self):
         # Used for testing only
         N = self.size

--- a/autograd/numpy/numpy_extra.py
+++ b/autograd/numpy/numpy_extra.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import numpy as np
+from copy import copy
 
 from autograd.core import (Node, VSpace, SparseObject, primitive,
                            register_node, register_vspace)
@@ -100,6 +101,15 @@ class ArrayVSpace(VSpace):
             return original_examples + np_scalar_examples + py_scalar_examples
         else:
             return original_examples
+
+    def __mul__(self, other):
+        if type(other) == type(self) and other.dtype == self.dtype:
+            product_vspace = copy(self)
+            product_vspace.shape += other.shape
+            product_vspace.size *= other.size
+            return product_vspace
+        else:
+            raise NotImplementedError
 
 class ComplexArrayVSpace(ArrayVSpace):
     iscomplex = True

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -3,6 +3,8 @@ import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd.util import check_grads
 from autograd import grad, jacobian
+from autograd.core import vspace
+from numpy.testing import assert_raises
 
 npr.seed(1)
 
@@ -41,3 +43,16 @@ def test_jacobian_higher_order():
 
     check_grads(lambda x: np.sum(np.sin(jacobian(fun)(x))), npr.randn(3))
     check_grads(lambda x: np.sum(np.sin(jacobian(jacobian(fun))(x))), npr.randn(3))
+
+def test_array_vspace_tensor_product():
+    a = np.array([2., 3.])
+    b = npr.randn(3, 4, 5)
+    product_vspace = vspace(a) * vspace(b)
+    assert product_vspace.shape == (2, 3, 4, 5)
+    assert product_vspace.size == 120
+
+def test_array_vspace_incompatible():
+    a = np.array([2., 3.], dtype=np.float32)
+    b = npr.randn(3, 4, 5)
+    with assert_raises(ValueError):
+        a * b


### PR DESCRIPTION
This change adds vspace tensor product (generalised outer product) computation by over-riding the `*` operator on vspaces, along the lines of https://en.wikipedia.org/wiki/Tensor_product#Tensor_product_of_vector_spaces. I suggested this [a little while ago](https://github.com/HIPS/autograd/pull/175#issuecomment-270624240), it's handy for computing the correct vspace for the Jacobian, and may be useful for other stuff in future.

With this change users also get a clear error message if a jacobian's input vspace is incompatible with the output vspace. For example, doing
```python
In [1]: from autograd import jacobian

In [2]: import autograd.numpy as np

In [3]: def f(x):
   ...:     return np.array(3., dtype=np.float32)
   ...:

In [4]: jacobian(f)(2.)
```
raises
```
ValueError: Input and output must be of scalar or array type, with matching dtype.
Input vspace:
ArrayVSpace_{'shape': (), 'size': 1, 'dtype': dtype('float64'), 'ndim': 0, 'scalartype': <class 'float'>}
Output vspace:
ArrayVSpace_{'shape': (), 'size': 1, 'dtype': dtype('float32'), 'ndim': 0, 'scalartype': <class 'float'>}
```