### PR TITLE
Use expit for sigmoid in vae example

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import autograd.numpy as np
 import autograd.numpy.random as npr
 import autograd.scipy.stats.norm as norm
+from autograd.scipy.special import expit as sigmoid
 
 from autograd import grad
 from autograd.optimizers import adam
@@ -29,7 +30,6 @@ def bernoulli_log_density(targets, unnormalized_logprobs):
     return np.sum(label_probabilities, axis=-1)   # Sum across pixels.
 
 def relu(x):    return np.maximum(0, x)
-def sigmoid(x): return 0.5 * (np.tanh(0.5 * x) + 1)
 
 def init_net_params(scale, layer_sizes, rs=npr.RandomState(0)):
     """Build a (weights, biases) tuples for all layers."""


### PR DESCRIPTION
This seems to improve performance a bit. On master

```
%timeit objective_grad(combined_init_params, 0)
102 ms ± 4.16 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
and with this change
```
%timeit objective_grad(combined_init_params, 0)
68.9 ms ± 1.38 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```