### PR TITLE
Remove seemingly unnecessary outgrad check

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -31,7 +31,6 @@ def backward_pass(g, end_node, start_node):
     outgrads = {end_node : (g, False)}
     assert_vspace_match(outgrads[end_node][0], end_node.vspace, None)
     for node in toposort(end_node, start_node):
-        if node not in outgrads: continue
         cur_outgrad = outgrads.pop(node)
         function, args, kwargs, parents = node.recipe
         for argnum, parent in parents:


### PR DESCRIPTION
I can't see what situation this line is checking for. Removing it doesn't cause any of the tests to fail. Note that if the check were ever relevant, then with it removed the line below:
```python
cur_outgrad = outgrads.pop(node)
```
would throw an exception, which doesn't happen in any of the tests.

I've also run the benchmarks comparing this commit to master, and it doesn't produce any significant changes.