### PR TITLE
Use vs.ndim in unbroadcast

### DIFF
--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -461,7 +461,7 @@ def match_complex(vs, x):
         return x
 
 def unbroadcast(vs, gvs, result, broadcast_idx=0):
-    while anp.ndim(result) > len(vs.shape):
+    while anp.ndim(result) > vs.ndim:
         result = anp.sum(result, axis=broadcast_idx)
     for axis, size in enumerate(vs.shape):
         if size == 1:


### PR DESCRIPTION
Now the tests fail when vs.ndim is incorrect as it was prior to 75c0254bfe318cd66b2ee3793ac14d6ceb94e3cc