### PR TITLE
Simplify dot grad

### DIFF
--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -1,5 +1,6 @@
 from . import numpy_wrapper as anp
-from .numpy_vjps import untake, balanced_eq, match_complex, replace_zero
+from .numpy_vjps import (untake, balanced_eq, match_complex, replace_zero,
+                         dot_0_adjoint, dot_1_adjoint)
 from autograd.core import (defjvp, defjvps, def_linear_wrt_arg, defjvp_argnum,
                            def_multilinear, vspace)
 from ..util import func
@@ -183,6 +184,9 @@ def_multilinear(anp.matmul)
 def_multilinear(anp.dot)
 def_multilinear(anp.tensordot)
 def_multilinear(anp.outer)
+
+def_multilinear(dot_0_adjoint)
+def_multilinear(dot_1_adjoint)
 
 def fwd_grad_concatenate_args(argnum, g, ans, gvs, vs, *axis_args, **kwargs):
     result = []

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -295,6 +295,8 @@ defvjps(anp.matmul, grad_matmul, [0, 1])
 
 def grad_dot(argnum, ans, vs, gvs, A, B):
     # TODO: rewrite to allow garbage collection of A or B (depending on argnum)
+    if argnum == 0:
+        return dot_0_adjoint(vs, gvs, B)
     A_ndim, B_ndim = anp.ndim(A), anp.ndim(B)
     if A_ndim == 0 or B_ndim == 0:
         axes = ([], [])
@@ -302,6 +304,27 @@ def grad_dot(argnum, ans, vs, gvs, A, B):
         axes = ([A_ndim - 1], [max(0, B_ndim - 2)])
     return grad_tensordot(argnum, ans, vs, gvs, A, B, axes=axes)
 defvjps(anp.dot, grad_dot, [0, 1])
+
+def dot_0_adjoint(A_vs, ans_vs, B):
+    # Returns the adjoint of the operator
+    # A |--> np.dot(A, B)
+    A_ndim, B_ndim = A_vs.ndim, anp.ndim(B)
+
+    if B_ndim == 0 or ans_vs.ndim == 0:
+        return lambda g: g * B
+    elif A_ndim == 0:
+        return lambda g: anp.dot(anp.ravel(g), anp.ravel(B))
+    elif B_ndim == 1:
+        return lambda g: g[..., anp.newaxis] * B
+    else:
+        B = anp.swapaxes(B, B_ndim-2, B_ndim-1)
+        if B_ndim > 2:
+            B = anp.reshape(B, (-1, anp.shape(B)[-1]))
+        def transposed(g):
+            if B_ndim > 2:
+                g = anp.reshape(g, A_vs.shape[:-1] + (-1,))
+            return anp.dot(g, B)
+        return transposed
 
 def grad_tensordot(argnum, ans, vs, gvs, A, B, axes=2):
     def vjp(g):

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -295,7 +295,7 @@ defvjps(anp.matmul, grad_matmul, [0, 1])
 
 @primitive
 def dot_0_adjoint(B, g, A_vs, ans_vs):
-    # Returns the adjoint of the operator
+    # The adjoint of the operator
     # A |--> np.dot(A, B)
     A_ndim, B_ndim = A_vs.ndim, anp.ndim(B)
 
@@ -314,7 +314,7 @@ def dot_0_adjoint(B, g, A_vs, ans_vs):
 
 @primitive
 def dot_1_adjoint(A, g, B_vs, ans_vs):
-    # Returns the adjoint of the operator
+    # The adjoint of the operator
     # B |--> np.dot(A, B)
     A_ndim, B_ndim = anp.ndim(A), B_vs.ndim
 

--- a/benchmarks/bench_numpy_vjps.py
+++ b/benchmarks/bench_numpy_vjps.py
@@ -18,6 +18,9 @@ A = npr.randn(2, 3, 4, 5)
 B = npr.randn(2, 3, 5, 4)
 g = npr.randn(2, 3, 4, 2, 3, 4)
 
+def time_dot():
+    np.dot(A, B)
+
 def time_dot_0():
     dot_0(A, B, g)
 

--- a/benchmarks/bench_numpy_vjps.py
+++ b/benchmarks/bench_numpy_vjps.py
@@ -1,0 +1,43 @@
+from autograd import make_vjp
+
+import autograd.numpy as np
+import autograd.numpy.random as npr
+
+dot_0 = lambda A, B, g: make_vjp(np.dot)(A, B)[0](g)
+dot_1 = lambda A, B, g: make_vjp(np.dot, argnum=1)(A, B)[0](g)
+
+dot_0_0 = lambda A, B, g: make_vjp(dot_0)(A, B, g)[0](A)
+dot_0_1 = lambda A, B, g: make_vjp(dot_0)(A, B, g)[0](A)
+dot_0_2 = lambda A, B, g: make_vjp(dot_0)(A, B, g)[0](A)
+
+dot_1_0 = lambda A, B, g: make_vjp(dot_1)(A, B, g)[0](B)
+dot_1_1 = lambda A, B, g: make_vjp(dot_1)(A, B, g)[0](B)
+dot_1_2 = lambda A, B, g: make_vjp(dot_1)(A, B, g)[0](B)
+
+A = npr.randn(2, 3, 4, 5)
+B = npr.randn(2, 3, 5, 4)
+g = npr.randn(2, 3, 4, 2, 3, 4)
+
+def time_dot_0():
+    dot_0(A, B, g)
+
+def time_dot_1():
+    dot_1(A, B, g)
+
+def time_dot_0_0():
+    dot_0_0(A, B, g)
+
+def time_dot_0_1():
+    dot_0_1(A, B, g)
+
+def time_dot_0_2():
+    dot_0_2(A, B, g)
+
+def time_dot_1_0():
+    dot_1_0(A, B, g)
+
+def time_dot_1_1():
+    dot_1_1(A, B, g)
+
+def time_dot_1_2():
+    dot_1_2(A, B, g)


### PR DESCRIPTION
This started as a response to Dougal's TODO [here](https://github.com/HIPS/autograd/blob/dougal-dev/autograd/numpy/numpy_vjps.py#L297) to ensure the grad of dot didn't depend on the variable differentiated wrt.

I realised that really the vjp of dot is just the adjoint of dot (as it is for all linear operators), and then I remembered the fact that the adjoint of the adjoint is just the original operator, and thought that turning the adjoint into a primitive and explicitly making its derivative equal to dot might improve performance of second and higher order derivatives.

For the n'th derivative the speedup could, I think, be linear in n (since the number of nodes was increasing by some constant amount each time a derivative was taken). Now dot and its adjoints (one for each arg) are closed under differentiation, meaning that effect won't occur. Anyway on the simple benchmarks I wrote:
```
    before     after       ratio
[dougal-dev] [simplify-dot-grad]
First derivatives
-  239.69μs    96.71μs      0.40  bench_numpy_vjps.time_dot_0
-  233.31μs   119.53μs      0.51  bench_numpy_vjps.time_dot_1
Second derivatives
-  300.94μs   135.22μs      0.45  bench_numpy_vjps.time_dot_0_0
-  302.74μs   134.07μs      0.44  bench_numpy_vjps.time_dot_0_1
-  299.35μs   131.23μs      0.44  bench_numpy_vjps.time_dot_0_2
-  522.63μs   219.09μs      0.42  bench_numpy_vjps.time_dot_1_0
-  509.52μs   209.25μs      0.41  bench_numpy_vjps.time_dot_1_2
-  510.89μs   208.79μs      0.41  bench_numpy_vjps.time_dot_1_1
```

I think there's still some scope for tidying up and maybe slightly optimizing what I've written. Also I think it would be worth doing something similar to this for the other linear primitives (some might turn out to be easier than dot).

EDIT: I've just tried the benchmarks on bigger arrays and the effect of these changes seems to be reversed, i.e. everything is a bit slower on this branch than dougal-dev. Need to fix that before merging.