### PR TITLE
Tensordot adjoints

### DIFF
--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -1,6 +1,7 @@
 from . import numpy_wrapper as anp
 from .numpy_vjps import (untake, balanced_eq, match_complex, replace_zero,
-                         dot_0_adjoint, dot_1_adjoint)
+                         dot_adjoint_0, dot_adjoint_1, tensordot_adjoint_0,
+                         tensordot_adjoint_1)
 from autograd.core import (defjvp, defjvps, def_linear_wrt_arg, defjvp_argnum,
                            def_multilinear, vspace)
 from ..util import func
@@ -185,8 +186,11 @@ def_multilinear(anp.dot)
 def_multilinear(anp.tensordot)
 def_multilinear(anp.outer)
 
-def_multilinear(dot_0_adjoint)
-def_multilinear(dot_1_adjoint)
+def_multilinear(dot_adjoint_0)
+def_multilinear(dot_adjoint_1)
+
+def_multilinear(tensordot_adjoint_0)
+def_multilinear(tensordot_adjoint_1)
 
 def fwd_grad_concatenate_args(argnum, g, ans, gvs, vs, *axis_args, **kwargs):
     result = []

--- a/benchmarks/bench_numpy_vjps.py
+++ b/benchmarks/bench_numpy_vjps.py
@@ -18,9 +18,6 @@ A = npr.randn(2, 3, 4, 5)
 B = npr.randn(2, 3, 5, 4)
 g = npr.randn(2, 3, 4, 2, 3, 4)
 
-def time_dot():
-    np.dot(A, B)
-
 def time_dot_0():
     dot_0(A, B, g)
 
@@ -44,3 +41,43 @@ def time_dot_1_1():
 
 def time_dot_1_2():
     dot_1_2(A, B, g)
+
+tensordot_0 = lambda A, B, G: make_vjp(np.tensordot)(A, B, 2)[0](G)
+tensordot_1 = lambda A, B, G: make_vjp(np.tensordot, argnum=1)(A, B, 2)[0](G)
+
+tensordot_0_0 = lambda A, B, G: make_vjp(tensordot_0)(A, B, G)[0](A)
+tensordot_0_1 = lambda A, B, G: make_vjp(tensordot_0)(A, B, G)[0](A)
+tensordot_0_2 = lambda A, B, G: make_vjp(tensordot_0)(A, B, G)[0](A)
+
+tensordot_1_0 = lambda A, B, G: make_vjp(tensordot_1)(A, B, G)[0](B)
+tensordot_1_1 = lambda A, B, G: make_vjp(tensordot_1)(A, B, G)[0](B)
+tensordot_1_2 = lambda A, B, G: make_vjp(tensordot_1)(A, B, G)[0](B)
+
+A = npr.randn(2, 3, 5, 4)
+B = npr.randn(5, 4, 2, 3)
+G = npr.randn(2, 3, 2, 3)
+
+def time_tensordot_0():
+    tensordot_0(A, B, G)
+
+def time_tensordot_1():
+    tensordot_1(A, B, G)
+
+def time_tensordot_0_0():
+    tensordot_0_0(A, B, G)
+
+def time_tensordot_0_1():
+    tensordot_0_1(A, B, G)
+
+def time_tensordot_0_2():
+    tensordot_0_2(A, B, G)
+
+def time_tensordot_1_0():
+    tensordot_1_0(A, B, G)
+
+def time_tensordot_1_1():
+    tensordot_1_1(A, B, G)
+
+def time_tensordot_1_2():
+    tensordot_1_2(A, B, G)
+

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -111,25 +111,25 @@ def test_matmul(): combo_check(np.matmul, [0, 1])(
                                [R(3), R(2, 3), R(2, 2, 3)],
                                [R(3), R(3, 4), R(2, 3, 4)])
 def test_matmul_broadcast(): combo_check(np.matmul, [0, 1])([R(1, 2, 2)], [R(3, 2, 1)])
-def test_tensordot_1(): combo_check(np.tensordot, [0, 1])(
+def test_tensordot_1(): combo_check(np.tensordot, [0, 1], order=3)(
                                     [R(1, 3), R(2, 3, 2)],
                                     [R(3),    R(3, 1),    R(3, 4, 2)],
                                     axes=[ [(1,), (0,)] ])
-def test_tensordot_2(): combo_check(np.tensordot, [0, 1])(
+def test_tensordot_2(): combo_check(np.tensordot, [0, 1], order=3)(
                                     [R(3),    R(3, 1),    R(3, 4, 2)],
                                     [R(1, 3), R(2, 3, 2)],
                                     axes=[ [(0,), (1,)] ])
-def test_tensordot_3(): combo_check(np.tensordot, [0, 1])(
+def test_tensordot_3(): combo_check(np.tensordot, [0, 1], order=3)(
                                     [R(2, 3),    R(2, 3, 4)],
                                     [R(1, 2, 3), R(2, 2, 3, 4)],
                                     axes=[ [(0, 1), (1, 2)] ,  [(1, 0), (2, 1)] ])
-def test_tensordot_4(): combo_check(np.tensordot, [0, 1])(
+def test_tensordot_4(): combo_check(np.tensordot, [0, 1], order=3)(
                                     [R(2, 2), R(4, 2, 2)],
                                     [R(2, 2), R(2, 2, 4)],
                                     axes=[1, 2])
-def test_tensordot_5(): combo_check(np.tensordot, [0, 1])([R(4)], [R()], axes=[0])
-def test_tensordot_6(): combo_check(np.tensordot, [0, 1])([R(2,6)], [R(6,3)], axes=[[[-1], [0]]])
-def test_tensordot_7(): combo_check(np.tensordot, [0, 1])([R(2,6)], [R(6,3)], axes=[[-1, 0]])
+def test_tensordot_5(): combo_check(np.tensordot, [0, 1], order=3)([R(4)], [R()], axes=[0])
+def test_tensordot_6(): combo_check(np.tensordot, [0, 1], order=3)([R(2,6)], [R(6,3)], axes=[[[-1], [0]]])
+def test_tensordot_7(): combo_check(np.tensordot, [0, 1], order=3)([R(2,6)], [R(6,3)], axes=[[-1, 0]])
 
 # Need custom tests because gradient is undefined when arguments are identical.
 def test_maximum(): combo_check(np.maximum, [0, 1])(


### PR DESCRIPTION
I've given tensordot the adjoint treatment, and this seems to have improved performance (though not as dramatically as for dot):

```
    before     after       ratio
  [4e517a01] [82068d0e]
-  366.45μs   241.00μs      0.66  bench_numpy_vjps.time_tensordot_1_0
-  380.09μs   238.82μs      0.63  bench_numpy_vjps.time_tensordot_1_2
-  379.86μs   236.12μs      0.62  bench_numpy_vjps.time_tensordot_1_1
```

There should also be a good knock on effect for primitives like inner and matmul which use these adjoints as their derivatives.

By the way, I just noticed that [from Numpy 1.4 Einsum is going to use the parallelized BLAS dot routine when possible](https://github.com/dgasmith/opt_einsum#news-opt_einsum-will-be-in-numpy-112-and-blas-features-in-numpy-114-call-opt_einsum-as-npeinsum-optimizetrue-this-repostiory-will-continue-to-provide-a-testing-ground-for-new-features). Maybe then we should have one efficient Einsum adjoint routine which is used by all of the linear operators, and that ought to have pretty good performance for everything and would be less code. @mattjj what do you reckon?

Edit: there's some more details https://github.com/numpy/numpy/pull/9425