### PR TITLE
Experiment no vspace checks

### DIFF
--- a/autograd/convenience_wrappers.py
+++ b/autograd/convenience_wrappers.py
@@ -192,7 +192,7 @@ def checkpoint(fun):
     for the backward pass. Useful to save memory, effectively trading off time
     and memory. See e.g. arxiv.org/abs/1604.06174.
     """
-    def wrapped_grad(argnum, ans, vs, gvs, args, kwargs):
+    def wrapped_grad(argnum, ans, args, kwargs):
         return make_vjp(fun, argnum)(*args, **kwargs)[0]
     wrapped = primitive(fun)
     defvjp_argnum(wrapped, wrapped_grad)

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from functools import partial
 from .tracer import (trace, primitive, notrace_primitive, Node, Box,
                      register_box, toposort)
-from .vspace import vspace, assert_vspace_match, register_vspace, VSpace
+from .vspace import vspace, register_vspace, VSpace
 from .util import func, subval
 
 def make_vjp(fun, x):
@@ -15,14 +15,12 @@ def make_vjp(fun, x):
     return vjp, end_value
 
 def backward_pass(g, end_node):
-    assert_vspace_match(g, end_node.vspace)
     outgrads = {end_node : (g, False)}
     for node in toposort(end_node):
         cur_outgrad = outgrads.pop(node)
         for parent, vjp in node.parents_and_vjps:
             outgrad = vjp(cur_outgrad[0])
-            assert_vspace_match(outgrad, parent.vspace)
-            outgrads[parent] = add_outgrads(parent.vspace, outgrads.get(parent), outgrad)
+            outgrads[parent] = add_outgrads(outgrads.get(parent), outgrad)
     return cur_outgrad[0]
 
 def make_jvp(fun, x):
@@ -38,39 +36,32 @@ def make_jvp(fun, x):
 class VJPNode(Node):
     __slots__ = ['vspace', 'parents', 'parents_and_vjps']
     def __init__(self, value, fun, args, kwargs, parent_argnums, parents):
-        self.vspace = vspace(value)
         self.parents = parents
         self.parents_and_vjps = [
-            (parent, primitive_vjp(fun, argnum, value, parent.vspace,
-                                   self.vspace, args, kwargs))
+            (parent, primitive_vjp(fun, argnum, value, args, kwargs))
             for argnum, parent in zip(parent_argnums, parents)]
 
     def initialize_root(self, value):
-        self.vspace = vspace(value)
         self.parents = []
         self.parents_and_vjps = []
 
 class JVPNode(Node):
     __slots__ = ['vspace', 'g']
     def __init__(self, value, fun, args, kwargs, parent_argnums, parents):
-        self.vspace = vspace(value)
         cur_g = None
         for argnum, parent in zip(parent_argnums, parents):
-            new_g = primitive_jvp(fun, argnum, parent.g, value, parent.vspace,
-                                  self.vspace, args, kwargs)
-            assert_vspace_match(new_g, self.vspace)
-            cur_g = add_outgrads(self.vspace, cur_g, new_g)
+            new_g = primitive_jvp(fun, argnum, parent.g, value, args, kwargs)
+            cur_g = add_outgrads(cur_g, new_g)
 
         self.g = cur_g[0]
 
     def initialize_root(self, x, g):
-        self.vspace = vspace(x)
-        assert_vspace_match(g, self.vspace)
         self.g = g
 
-def add_outgrads(vs, prev_g_flagged, g):
+def add_outgrads(prev_g_flagged, g):
     sparse = type(g) in sparse_object_types
     if prev_g_flagged:
+        vs = vspace(g)
         prev_g, mutable = prev_g_flagged
         if mutable:
             if sparse:
@@ -85,7 +76,7 @@ def add_outgrads(vs, prev_g_flagged, g):
                 return vs.add(prev_g, g), True
     else:
         if sparse:
-            return sparse_add(vs.zeros(), g), True
+            return sparse_add(vspace(g).zeros(), g), True
         else:
             return g, False
 
@@ -105,7 +96,7 @@ def zero_vjp(ans, vs, gvs, *args, **kwargs):
 
 primitive_vjps = defaultdict(dict)
 
-def primitive_vjp(fun, argnum, ans, vs, gvs, args, kwargs):
+def primitive_vjp(fun, argnum, ans, args, kwargs):
     try:
         vjp = primitive_vjps[fun][argnum]
     except KeyError:
@@ -114,7 +105,7 @@ def primitive_vjp(fun, argnum, ans, vs, gvs, args, kwargs):
         else:
             errstr = "Gradient of {0} not yet implemented."
         raise NotImplementedError(errstr.format(repr(fun), argnum))
-    return vjp(ans, vs, gvs, args, kwargs)
+    return vjp(ans, vspace(args[argnum]), vspace(ans), args, kwargs)
 
 def defvjp(fun, vjpmaker, argnum=0):
     def vjp_fixed_args(ans, vs, gvs, args, kwargs):
@@ -159,9 +150,9 @@ defvjp(func(VSpace.scalar_mul), lambda ans, vs, gvs, vs_, x, a: lambda g:
 defvjp(func(VSpace.scalar_mul), lambda ans, vs, gvs, vs_, x, a: lambda g:
        gvs.inner_prod(g, gvs.covector(x)), argnum=2)
 
-def primitive_jvp(fun, argnum, g, ans, gvs, vs, args, kwargs):
+def primitive_jvp(fun, argnum, g, ans, args, kwargs):
     try:
-        return primitive_jvps[fun][argnum](g, ans, gvs, vs, args, kwargs)
+        return primitive_jvps[fun][argnum](g, ans, vspace(args[argnum]), vspace(ans), args, kwargs)
     except KeyError:
         raise NotImplementedError("JVP of {} wrt arg number {} not yet implemented"
                                   .format(fun.__name__, argnum))

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -10,11 +10,11 @@ from .numpy_boxes import ArrayBox
 def_linear_wrt_arg(func(ArrayBox.__getitem__))
 def_linear_wrt_arg(untake)
 
-defjvp_argnum(anp.array_from_args, lambda argnum, g, ans, gvs, vs, args, kwargs: untake(g, argnum-2, vs))
-defjvp(anp._array_from_scalar_or_array, lambda g, ans, gvs, vs, args, kwargs, _: anp._array_from_scalar_or_array(args, kwargs, g), argnum=2)
+defjvp_argnum(anp.array_from_args, lambda argnum, g, ans, args, kwargs: untake(g, argnum-2, vspace(ans)))
+defjvp(anp._array_from_scalar_or_array, lambda g, ans, args, kwargs, _: anp._array_from_scalar_or_array(args, kwargs, g), argnum=2)
 
 # ----- Functions that are constant w.r.t. continuous inputs -----
-defjvp(anp.nan_to_num, lambda g, ans, gvs, vs, x: anp.where(anp.isfinite(x), g, 0.))
+defjvp(anp.nan_to_num, lambda g, ans, x: anp.where(anp.isfinite(x), g, 0.))
 
 # ----- Binary ufuncs (linear) -----
 def_multilinear(anp.multiply)
@@ -22,30 +22,30 @@ def_linear_wrt_arg(anp.divide)
 def_linear_wrt_arg(anp.true_divide)
 
 # ----- Binary ufuncs -----
-defjvp(anp.add,        lambda g, ans, gvs, vs, x, y : broadcast(gvs, vs, g))
-defjvp(anp.add,        lambda g, ans, gvs, vs, x, y : broadcast(gvs, vs, g), argnum=1)
-defjvp(anp.subtract,   lambda g, ans, gvs, vs, x, y : broadcast(gvs, vs, g))
-defjvp(anp.subtract,   lambda g, ans, gvs, vs, x, y : broadcast(gvs, vs, -g), argnum=1)
-defjvp(anp.divide,     lambda g, ans, gvs, vs, x, y : - g * x / y**2, argnum=1)
-defjvp(anp.maximum,    lambda g, ans, gvs, vs, x, y : g * balanced_eq(x, ans, y))
-defjvp(anp.maximum,    lambda g, ans, gvs, vs, x, y : g * balanced_eq(y, ans, x), argnum=1)
-defjvp(anp.minimum,    lambda g, ans, gvs, vs, x, y : g * balanced_eq(x, ans, y))
-defjvp(anp.minimum,    lambda g, ans, gvs, vs, x, y : g * balanced_eq(y, ans, x), argnum=1)
-defjvp(anp.fmax,       lambda g, ans, gvs, vs, x, y : g * balanced_eq(x, ans, y))
-defjvp(anp.fmax,       lambda g, ans, gvs, vs, x, y : g * balanced_eq(y, ans, x), argnum=1)
-defjvp(anp.fmin,       lambda g, ans, gvs, vs, x, y : g * balanced_eq(x, ans, y))
-defjvp(anp.fmin,       lambda g, ans, gvs, vs, x, y : g * balanced_eq(y, ans, x), argnum=1)
-defjvp(anp.logaddexp,  lambda g, ans, gvs, vs, x, y : g * anp.exp(x-ans))
-defjvp(anp.logaddexp,  lambda g, ans, gvs, vs, x, y : g * anp.exp(y-ans), argnum=1)
-defjvp(anp.logaddexp2, lambda g, ans, gvs, vs, x, y : g * 2**(x-ans))
-defjvp(anp.logaddexp2, lambda g, ans, gvs, vs, x, y : g * 2**(y-ans), argnum=1)
-defjvp(anp.true_divide,lambda g, ans, gvs, vs, x, y : - g * x / y**2, argnum=1)
-defjvp(anp.mod,        lambda g, ans, gvs, vs, x, y : broadcast(gvs, vs, g))
-defjvp(anp.remainder,  lambda g, ans, gvs, vs, x, y : broadcast(gvs, vs, g))
-defjvp(anp.mod,        lambda g, ans, gvs, vs, x, y : -g * anp.floor(x/y), argnum=1)
-defjvp(anp.remainder,  lambda g, ans, gvs, vs, x, y : -g * anp.floor(x/y), argnum=1)
-defjvp(anp.power,      lambda g, ans, gvs, vs, x, y : g * y * x ** anp.where(y, y - 1, 1.))
-defjvp(anp.power,      lambda g, ans, gvs, vs, x, y : g * anp.log(replace_zero(x, 1.)) * x ** y, argnum=1)
+defjvp(anp.add,        lambda g, ans, x, y : broadcast(x, ans, g))
+defjvp(anp.add,        lambda g, ans, x, y : broadcast(y, ans, g), argnum=1)
+defjvp(anp.subtract,   lambda g, ans, x, y : broadcast(x, ans, g))
+defjvp(anp.subtract,   lambda g, ans, x, y : broadcast(y, ans, -g), argnum=1)
+defjvp(anp.divide,     lambda g, ans, x, y : - g * x / y**2, argnum=1)
+defjvp(anp.maximum,    lambda g, ans, x, y : g * balanced_eq(x, ans, y))
+defjvp(anp.maximum,    lambda g, ans, x, y : g * balanced_eq(y, ans, x), argnum=1)
+defjvp(anp.minimum,    lambda g, ans, x, y : g * balanced_eq(x, ans, y))
+defjvp(anp.minimum,    lambda g, ans, x, y : g * balanced_eq(y, ans, x), argnum=1)
+defjvp(anp.fmax,       lambda g, ans, x, y : g * balanced_eq(x, ans, y))
+defjvp(anp.fmax,       lambda g, ans, x, y : g * balanced_eq(y, ans, x), argnum=1)
+defjvp(anp.fmin,       lambda g, ans, x, y : g * balanced_eq(x, ans, y))
+defjvp(anp.fmin,       lambda g, ans, x, y : g * balanced_eq(y, ans, x), argnum=1)
+defjvp(anp.logaddexp,  lambda g, ans, x, y : g * anp.exp(x-ans))
+defjvp(anp.logaddexp,  lambda g, ans, x, y : g * anp.exp(y-ans), argnum=1)
+defjvp(anp.logaddexp2, lambda g, ans, x, y : g * 2**(x-ans))
+defjvp(anp.logaddexp2, lambda g, ans, x, y : g * 2**(y-ans), argnum=1)
+defjvp(anp.true_divide,lambda g, ans, x, y : - g * x / y**2, argnum=1)
+defjvp(anp.mod,        lambda g, ans, x, y : broadcast(x, ans, g))
+defjvp(anp.remainder,  lambda g, ans, x, y : broadcast(x, ans, g))
+defjvp(anp.mod,        lambda g, ans, x, y : -g * anp.floor(x/y), argnum=1)
+defjvp(anp.remainder,  lambda g, ans, x, y : -g * anp.floor(x/y), argnum=1)
+defjvp(anp.power,      lambda g, ans, x, y : g * y * x ** anp.where(y, y - 1, 1.))
+defjvp(anp.power,      lambda g, ans, x, y : g * anp.log(replace_zero(x, 1.)) * x ** y, argnum=1)
 
 # ----- Simple grads (linear) -----
 def_linear_wrt_arg(anp.negative)
@@ -80,40 +80,40 @@ def_multilinear(anp.cross)
 
 # ----- Simple grads -----
 defjvp(anp.abs,
-    lambda g, ans, gvs, vs, x : anp.real(g * replace_zero(anp.conj(x), 0.)) / replace_zero(ans, 1.))
-defjvp(anp.fabs,        lambda g, ans, gvs, vs, x : anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defjvp(anp.absolute,    lambda g, ans, gvs, vs, x : anp.real(g * anp.conj(x)) / ans)
-defjvp(anp.reciprocal,  lambda g, ans, gvs, vs, x : - g / x**2)
-defjvp(anp.exp,         lambda g, ans, gvs, vs, x : ans * g)
-defjvp(anp.exp2,        lambda g, ans, gvs, vs, x : ans * anp.log(2) * g)
-defjvp(anp.expm1,       lambda g, ans, gvs, vs, x : (ans + 1) * g)
-defjvp(anp.log,         lambda g, ans, gvs, vs, x : g / x)
-defjvp(anp.log2,        lambda g, ans, gvs, vs, x : g / x / anp.log(2))
-defjvp(anp.log10,       lambda g, ans, gvs, vs, x : g / x / anp.log(10))
-defjvp(anp.log1p,       lambda g, ans, gvs, vs, x : g / (x + 1))
-defjvp(anp.sin,         lambda g, ans, gvs, vs, x : g * anp.cos(x))
-defjvp(anp.cos,         lambda g, ans, gvs, vs, x : - g * anp.sin(x))
-defjvp(anp.tan,         lambda g, ans, gvs, vs, x : g / anp.cos(x) **2)
-defjvp(anp.arcsin,      lambda g, ans, gvs, vs, x : g / anp.sqrt(1 - x**2))
-defjvp(anp.arccos,      lambda g, ans, gvs, vs, x :-g / anp.sqrt(1 - x**2))
-defjvp(anp.arctan,      lambda g, ans, gvs, vs, x : g / (1 + x**2))
-defjvp(anp.sinh,        lambda g, ans, gvs, vs, x : g * anp.cosh(x))
-defjvp(anp.cosh,        lambda g, ans, gvs, vs, x : g * anp.sinh(x))
-defjvp(anp.tanh,        lambda g, ans, gvs, vs, x : g / anp.cosh(x) **2)
-defjvp(anp.arcsinh,     lambda g, ans, gvs, vs, x : g / anp.sqrt(x**2 + 1))
-defjvp(anp.arccosh,     lambda g, ans, gvs, vs, x : g / anp.sqrt(x**2 - 1))
-defjvp(anp.arctanh,     lambda g, ans, gvs, vs, x : g / (1 - x**2))
-defjvp(anp.square,      lambda g, ans, gvs, vs, x : g * 2 * x)
-defjvp(anp.sqrt,        lambda g, ans, gvs, vs, x : g * 0.5 * x**-0.5)
-defjvp(anp.sinc,        lambda g, ans, gvs, vs, x : g * (anp.cos(anp.pi*x)*anp.pi*x - anp.sin(anp.pi*x))/(anp.pi*x**2))
-defjvp(anp.clip,        lambda g, ans, gvs, vs, x, a_min, a_max : g * anp.logical_and(ans != a_min, ans != a_max))
-defjvp(anp.real_if_close, lambda g, ans, gvs, vs, x : match_complex(vs, g))
-defjvp(anp.real,   lambda g, ans, gvs, vs, x   : anp.real(g))
-defjvp(anp.imag,   lambda g, ans, gvs, vs, x   : match_complex(vs, -1j * g))
-defjvp(anp.conj,   lambda g, ans, gvs, vs, x   : anp.conj(g))
-defjvp(anp.angle,  lambda g, ans, gvs, vs, x   : match_complex(vs, g * anp.conj(x * 1j) / anp.abs(x)**2))
-defjvp(anp.where,  lambda g, ans, gvs, vs, c, x=None, y=None : anp.where(c, g, anp.zeros(anp.shape(g))), argnum=1)
-defjvp(anp.where,  lambda g, ans, gvs, vs, c, x=None, y=None : anp.where(c, anp.zeros(g.shape), g), argnum=2)
+    lambda g, ans, x : anp.real(g * replace_zero(anp.conj(x), 0.)) / replace_zero(ans, 1.))
+defjvp(anp.fabs,        lambda g, ans, x : anp.sign(x) * g)  # fabs doesn't take complex numbers.
+defjvp(anp.absolute,    lambda g, ans, x : anp.real(g * anp.conj(x)) / ans)
+defjvp(anp.reciprocal,  lambda g, ans, x : - g / x**2)
+defjvp(anp.exp,         lambda g, ans, x : ans * g)
+defjvp(anp.exp2,        lambda g, ans, x : ans * anp.log(2) * g)
+defjvp(anp.expm1,       lambda g, ans, x : (ans + 1) * g)
+defjvp(anp.log,         lambda g, ans, x : g / x)
+defjvp(anp.log2,        lambda g, ans, x : g / x / anp.log(2))
+defjvp(anp.log10,       lambda g, ans, x : g / x / anp.log(10))
+defjvp(anp.log1p,       lambda g, ans, x : g / (x + 1))
+defjvp(anp.sin,         lambda g, ans, x : g * anp.cos(x))
+defjvp(anp.cos,         lambda g, ans, x : - g * anp.sin(x))
+defjvp(anp.tan,         lambda g, ans, x : g / anp.cos(x) **2)
+defjvp(anp.arcsin,      lambda g, ans, x : g / anp.sqrt(1 - x**2))
+defjvp(anp.arccos,      lambda g, ans, x :-g / anp.sqrt(1 - x**2))
+defjvp(anp.arctan,      lambda g, ans, x : g / (1 + x**2))
+defjvp(anp.sinh,        lambda g, ans, x : g * anp.cosh(x))
+defjvp(anp.cosh,        lambda g, ans, x : g * anp.sinh(x))
+defjvp(anp.tanh,        lambda g, ans, x : g / anp.cosh(x) **2)
+defjvp(anp.arcsinh,     lambda g, ans, x : g / anp.sqrt(x**2 + 1))
+defjvp(anp.arccosh,     lambda g, ans, x : g / anp.sqrt(x**2 - 1))
+defjvp(anp.arctanh,     lambda g, ans, x : g / (1 - x**2))
+defjvp(anp.square,      lambda g, ans, x : g * 2 * x)
+defjvp(anp.sqrt,        lambda g, ans, x : g * 0.5 * x**-0.5)
+defjvp(anp.sinc,        lambda g, ans, x : g * (anp.cos(anp.pi*x)*anp.pi*x - anp.sin(anp.pi*x))/(anp.pi*x**2))
+defjvp(anp.clip,        lambda g, ans, x, a_min, a_max : g * anp.logical_and(ans != a_min, ans != a_max))
+defjvp(anp.real_if_close, lambda g, ans, x : match_complex(ans, g))
+defjvp(anp.real,   lambda g, ans, x   : anp.real(g))
+defjvp(anp.imag,   lambda g, ans, x   : match_complex(ans, -1j * g))
+defjvp(anp.conj,   lambda g, ans, x   : anp.conj(g))
+defjvp(anp.angle,  lambda g, ans, x   : match_complex(ans, g * anp.conj(x * 1j) / anp.abs(x)**2))
+defjvp(anp.where,  lambda g, ans, c, x=None, y=None : anp.where(c, g, anp.zeros(anp.shape(g))), argnum=1)
+defjvp(anp.where,  lambda g, ans, c, x=None, y=None : anp.where(c, anp.zeros(g.shape), g), argnum=2)
 
 # ----- Trickier grads -----
 def_linear_wrt_arg(anp.diff)
@@ -123,11 +123,12 @@ def_multilinear(anp.kron)
 def_linear_wrt_arg(anp.transpose)
 def_linear_wrt_arg(anp.sum)
 def_linear_wrt_arg(anp.mean)
-defjvp(anp.prod, lambda g, ans, gvs, vs, x, axis=None, keepdims=False: ans * anp.sum(g / x, axis=axis, keepdims=keepdims))
-defjvp(anp.linspace, lambda g, ans, gvs, vs, start, stop, *args, **kwargs: anp.linspace(g, 0, *args, **kwargs), argnum=0)
-defjvp(anp.linspace, lambda g, ans, gvs, vs, start, stop, *args, **kwargs: anp.linspace(0, g, *args, **kwargs), argnum=1)
+defjvp(anp.prod, lambda g, ans, x, axis=None, keepdims=False: ans * anp.sum(g / x, axis=axis, keepdims=keepdims))
+defjvp(anp.linspace, lambda g, ans, start, stop, *args, **kwargs: anp.linspace(g, 0, *args, **kwargs), argnum=0)
+defjvp(anp.linspace, lambda g, ans, start, stop, *args, **kwargs: anp.linspace(0, g, *args, **kwargs), argnum=1)
 
-def forward_grad_np_var(g, ans, gvs, vs, x, axis=None, ddof=0, keepdims=False):
+def forward_grad_np_var(g, ans, x, axis=None, ddof=0, keepdims=False):
+    gvs = vspace(x)
     if axis is None:
         if gvs.iscomplex:
             num_reps = gvs.size / 2
@@ -143,7 +144,8 @@ def forward_grad_np_var(g, ans, gvs, vs, x, axis=None, ddof=0, keepdims=False):
             (num_reps - ddof))
 defjvp(anp.var, forward_grad_np_var)
 
-def forward_grad_np_std(g, ans, gvs, vs, x, axis=None, ddof=0, keepdims=False):
+def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False):
+    gvs = vspace(x)
     if axis is None:
         if gvs.iscomplex:
             num_reps = gvs.size / 2
@@ -161,7 +163,7 @@ def forward_grad_np_std(g, ans, gvs, vs, x, axis=None, ddof=0, keepdims=False):
             ((num_reps - ddof) * ans))
 defjvp(anp.std, forward_grad_np_std)
 
-def fwd_grad_chooser(g, ans, gvs, vs, x, axis=None, keepdims=False):
+def fwd_grad_chooser(g, ans, x, axis=None, keepdims=False):
     if anp.isscalar(x):
         return g
     if not keepdims:
@@ -179,7 +181,7 @@ defjvp(anp.min, fwd_grad_chooser)
 defjvp(anp.amax, fwd_grad_chooser)
 defjvp(anp.amin, fwd_grad_chooser)
 
-defjvp(anp.cumsum, lambda g, ans, gvs, vs, x, axis=None: anp.cumsum(g, axis=axis))
+defjvp(anp.cumsum, lambda g, ans, x, axis=None: anp.cumsum(g, axis=axis))
 
 def_multilinear(anp.inner)
 def_multilinear(anp.matmul)
@@ -193,7 +195,7 @@ def_multilinear(dot_adjoint_1)
 def_multilinear(tensordot_adjoint_0)
 def_multilinear(tensordot_adjoint_1)
 
-def fwd_grad_concatenate_args(argnum, g, ans, gvs, vs, axis_args, kwargs):
+def fwd_grad_concatenate_args(argnum, g, ans, axis_args, kwargs):
     result = []
     for i in range(1, len(axis_args)):
         if i == argnum:
@@ -203,20 +205,20 @@ def fwd_grad_concatenate_args(argnum, g, ans, gvs, vs, axis_args, kwargs):
     return anp.concatenate_args(axis_args[0], *result)
 defjvp_argnum(anp.concatenate_args, fwd_grad_concatenate_args)
 
-def fwd_grad_sort(g, ans, gvs, vs, x, axis=-1, kind='quicksort', order=None):
+def fwd_grad_sort(g, ans, x, axis=-1, kind='quicksort', order=None):
     sort_perm = anp.argsort(x, axis, kind, order)
     return g[sort_perm]
 defjvp(anp.sort, fwd_grad_sort)
-defjvp(anp.msort, lambda g, ans, gvs, vs, x: fwd_grad_sort(g, ans, gvs, vs, x,
+defjvp(anp.msort, lambda g, ans, x: fwd_grad_sort(g, ans, vspace(g), vspace(ans), x,
                                                           axis=0))
 
-def fwd_grad_partition(g, ans, gvs, vs, x, kth, axis=-1, kind='introselect', order=None):
+def fwd_grad_partition(g, ans, x, kth, axis=-1, kind='introselect', order=None):
     partition_perm = anp.argpartition(x, kth, axis, kind, order)
     return g[partition_perm]
 defjvp(anp.partition, fwd_grad_partition)
 
 def atleast_jvpmaker(fun):
-    def jvp(g, ans, gvs, vs, *arys):
+    def jvp(g, ans, *arys):
         if len(arys) > 1:
             raise NotImplementedError("Can't handle multiple arguments yet.")
         return fun(g)
@@ -227,7 +229,10 @@ defjvp(anp.atleast_3d, atleast_jvpmaker(anp.atleast_3d))
 
 def_multilinear(anp.einsum)
 
-def broadcast(gvs, vs, result, broadcast_idx=0):
+def broadcast(x, ans, result, broadcast_idx=0):
+    vs = vspace(ans)
+    gvs = vspace(x)
+
     while anp.ndim(result) < len(vs.shape):
         result = anp.expand_dims(result, 0)
     for axis, size in enumerate(anp.shape(result)):

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -157,7 +157,7 @@ def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False):
         num_reps = anp.prod(anp.array(gvs.shape)[list(axis)])
 
     if num_reps <= 1:
-        return vs.zeros()
+        return vspace(ans).zeros()
     x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True))
     return (anp.sum(anp.real(g * x_minus_mean), axis=axis, keepdims=keepdims) /
             ((num_reps - ddof) * ans))
@@ -209,8 +209,7 @@ def fwd_grad_sort(g, ans, x, axis=-1, kind='quicksort', order=None):
     sort_perm = anp.argsort(x, axis, kind, order)
     return g[sort_perm]
 defjvp(anp.sort, fwd_grad_sort)
-defjvp(anp.msort, lambda g, ans, x: fwd_grad_sort(g, ans, vspace(g), vspace(ans), x,
-                                                          axis=0))
+defjvp(anp.msort, lambda g, ans, x: fwd_grad_sort(g, ans, x, axis=0))
 
 def fwd_grad_partition(g, ans, x, kth, axis=-1, kind='introselect', order=None):
     partition_perm = anp.argpartition(x, kth, axis, kind, order)

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -220,13 +220,14 @@ defjvp(anp.atleast_3d, atleast_jvpmaker(anp.atleast_3d))
 
 def_multilinear(anp.einsum)
 
+# TODO(mattjj): can we call np.broadcast_to or a related function instead?
 def broadcast(x, target):
-    target_shape, target_ndim, target_iscomplex = anp.metadata(target)
+    target_shape, target_ndim, target_dtype, target_iscomplex = anp.metadata(target)
     while anp.ndim(x) < target_ndim:
         x = anp.expand_dims(x, 0)
     for axis, size in enumerate(anp.shape(x)):
         if size == 1:
             x = anp.repeat(x, target_shape[axis], axis=axis)
     if target_iscomplex and not anp.iscomplexobj(x):
-        x = x + 0j
+        x = x + 0j  # TODO(mattjj): this might promote the dtype
     return x

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -199,7 +199,7 @@ def grad_transpose(ans, x, axes=None):
     return lambda g: anp.transpose(g, axes)
 defvjp(anp.transpose, grad_transpose)
 
-def repeat_to_match_shape(g, shape, axis, keepdims):
+def repeat_to_match_shape(g, shape, dtype, axis, keepdims):
     """Returns the array g repeated along axis to fit vector space vs.
        Also returns the number of repetitions of the array."""
     if shape == ():
@@ -208,61 +208,61 @@ def repeat_to_match_shape(g, shape, axis, keepdims):
     new_shape = onp.array(shape)
     new_shape[axis] = 1
     num_reps = onp.prod(onp.array(shape)[axis])
-    return anp.reshape(g, new_shape) + onp.zeros(shape), num_reps
+    return anp.reshape(g, new_shape) + onp.zeros(shape, dtype=dtype), num_reps
 
 def grad_np_sum(ans, x, axis=None, keepdims=False, dtype=None):
-    shape = anp.shape(x)
-    return lambda g: repeat_to_match_shape(g, shape, axis, keepdims)[0]
+    shape, dtype = anp.shape(x), anp.result_type(x)
+    return lambda g: repeat_to_match_shape(g, shape, dtype, axis, keepdims)[0]
 defvjp(anp.sum, grad_np_sum)
 
 def grad_np_mean(ans, x, axis=None, keepdims=False):
-    shape = anp.shape(x)
+    shape, dtype = anp.shape(x), anp.result_type(x)
     def vjp(g):
-        g_repeated, num_reps = repeat_to_match_shape(g, shape, axis, keepdims)
+        g_repeated, num_reps = repeat_to_match_shape(g, shape, dtype, axis, keepdims)
         return g_repeated / num_reps
     return vjp
 defvjp(anp.mean, grad_np_mean)
 
 def grad_np_prod(ans, x, axis=None, keepdims=False): # TODO: Support tuples of axes.
-    shape = anp.shape(x)
+    shape, dtype = anp.shape(x), anp.result_type(x)
     def vjp(g):
-        g_repeated, _ = repeat_to_match_shape(g * ans, shape, axis, keepdims)
+        g_repeated, _ = repeat_to_match_shape(g * ans, shape, dtype, axis, keepdims)
         return g_repeated / x
     return vjp
 defvjp(anp.prod, grad_np_prod)
 
 def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False):
-    shape, _, iscomplex = anp.metadata(x)
+    shape, _, dtype, iscomplex = anp.metadata(x)
     def vjp(g):
         if iscomplex:
             g = g + 0j
-        g_repeated, num_reps = repeat_to_match_shape(g, shape, axis, keepdims)
+        g_repeated, num_reps = repeat_to_match_shape(g, shape, dtype, axis, keepdims)
         x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True))
         return 2.0 * g_repeated * x_minus_mean / (num_reps - ddof)
     return vjp
 defvjp(anp.var, grad_np_var)
 
 def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False):
-    shape, _, iscomplex = anp.metadata(x)
+    shape, _, dtype, iscomplex = anp.metadata(x)
     def vjp(g):
         if iscomplex:
             g = g + 0j
-        g_repeated, num_reps = repeat_to_match_shape(g, shape, axis, keepdims)  # Avoid division by zero.
+        g_repeated, num_reps = repeat_to_match_shape(g, shape, dtype, axis, keepdims)  # Avoid division by zero.
         if num_reps <= 1:
             return g_repeated * 0.0
         else:
-            g_repeated, num_reps = repeat_to_match_shape(g / ans, shape, axis, keepdims)
+            g_repeated, num_reps = repeat_to_match_shape(g / ans, shape, dtype, axis, keepdims)
             x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True))
             return g_repeated * x_minus_mean / (num_reps - ddof)
     return vjp
 defvjp(anp.std, grad_np_std)
 
 def grad_chooser(ans, x, axis=None, keepdims=None):
-    shape = anp.shape(x)
+    shape, dtype = anp.shape(x), anp.result_type(x)
     def vjp(g):
         """Builds gradient of functions that choose a single item, such as min or max."""
-        g_repeated, _ = repeat_to_match_shape(g, shape, axis, keepdims)
-        argmax_locations = x == repeat_to_match_shape(ans, shape, axis, keepdims)[0]
+        g_repeated, _ = repeat_to_match_shape(g, shape, dtype, axis, keepdims)
+        argmax_locations = x == repeat_to_match_shape(ans, shape, dtype, axis, keepdims)[0]
         return g_repeated * argmax_locations \
             / onp.sum(argmax_locations, axis=axis, keepdims=True)
     return vjp
@@ -536,7 +536,7 @@ def match_complex(target, x):
         return x
 
 def unbroadcast(x, target_meta, broadcast_idx=0):
-    target_shape, target_ndim, target_iscomplex = target_meta
+    target_shape, target_ndim, dtype, target_iscomplex = target_meta
     while anp.ndim(x) > target_ndim:
         x = anp.sum(x, axis=broadcast_idx)
     for axis, size in enumerate(target_shape):

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -336,7 +336,7 @@ def dot_adjoint_1(A, G, B_vs):
 defvjp(anp.dot, lambda ans, A, B: lambda g: dot_adjoint_0(B, g, vspace(A)))
 defvjp(anp.dot, lambda ans, A, B: lambda g: dot_adjoint_1(A, g, vspace(B)), 1)
 
-defvjp(dot_adjoint_0, lambda ans, B, g, A_vs: lambda A: dot_adjoint_1(A, g, vspace(A)))
+defvjp(dot_adjoint_0, lambda ans, B, g, A_vs: lambda A: dot_adjoint_1(A, g, vspace(B)))
 defvjp(dot_adjoint_0, lambda ans, B, g, *args: lambda A: anp.dot(A, B), 1)
 
 defvjp(dot_adjoint_1, lambda ans, A, g, B_vs: lambda B: dot_adjoint_0(B, g, vspace(A)))

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -12,120 +12,122 @@ from .numpy_boxes import ArrayBox
 # ----- Functions that are constant w.r.t. continuous inputs -----
 
 defvjp_is_zero(anp.where, argnums=(0,))
-defvjp(anp.nan_to_num, lambda ans, vs, gvs, x: lambda g: anp.where(anp.isfinite(x), g, 0.))
+defvjp(anp.nan_to_num, lambda ans, x: lambda g: anp.where(anp.isfinite(x), g, 0.))
 
 # ----- Binary ufuncs -----
 
-defvjp(anp.add,         lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g))
-defvjp(anp.add,         lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g), argnum=1)
-defvjp(anp.multiply,    lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, y * g))
-defvjp(anp.multiply,    lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, x * g), argnum=1)
-defvjp(anp.subtract,    lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g))
-defvjp(anp.subtract,    lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, -g), argnum=1)
-defvjp(anp.divide,      lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs,   g / y))
-defvjp(anp.divide,      lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, - g * x / y**2), argnum=1)
-defvjp(anp.maximum,     lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * balanced_eq(x, ans, y)))
-defvjp(anp.maximum,     lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * balanced_eq(y, ans, x)), argnum=1)
-defvjp(anp.minimum,     lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * balanced_eq(x, ans, y)))
-defvjp(anp.minimum,     lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * balanced_eq(y, ans, x)), argnum=1)
-defvjp(anp.fmax,        lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * balanced_eq(x, ans, y)))
-defvjp(anp.fmax,        lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * balanced_eq(y, ans, x)), argnum=1)
-defvjp(anp.fmin,        lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * balanced_eq(x, ans, y)))
-defvjp(anp.fmin,        lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * balanced_eq(y, ans, x)), argnum=1)
-defvjp(anp.logaddexp,   lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * anp.exp(x-ans)))
-defvjp(anp.logaddexp,   lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * anp.exp(y-ans)), argnum=1)
-defvjp(anp.logaddexp2,  lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * 2**(x-ans)))
-defvjp(anp.logaddexp2,  lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g * 2**(y-ans)), argnum=1)
-defvjp(anp.true_divide, lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g / y))
-defvjp(anp.true_divide, lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, - g * x / y**2), argnum=1)
-defvjp(anp.mod,         lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g))
-defvjp(anp.remainder,   lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, g))
-defvjp(anp.mod,         lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, -g * anp.floor(x/y)), argnum=1)
-defvjp(anp.remainder,   lambda ans, vs, gvs, x, y : lambda g: unbroadcast(vs, gvs, -g * anp.floor(x/y)), argnum=1)
+defvjp(anp.add,         lambda ans, x, y : lambda g: unbroadcast(x, g, g))
+defvjp(anp.add,         lambda ans, x, y : lambda g: unbroadcast(y, g, g), argnum=1)
+defvjp(anp.multiply,    lambda ans, x, y : lambda g: unbroadcast(x, g, y * g))
+defvjp(anp.multiply,    lambda ans, x, y : lambda g: unbroadcast(y, g, x * g), argnum=1)
+defvjp(anp.subtract,    lambda ans, x, y : lambda g: unbroadcast(x, g, g))
+defvjp(anp.subtract,    lambda ans, x, y : lambda g: unbroadcast(y, g, -g), argnum=1)
+defvjp(anp.divide,      lambda ans, x, y : lambda g: unbroadcast(x, g,   g / y))
+defvjp(anp.divide,      lambda ans, x, y : lambda g: unbroadcast(y, g, - g * x / y**2), argnum=1)
+defvjp(anp.maximum,     lambda ans, x, y : lambda g: unbroadcast(x, g, g * balanced_eq(x, ans, y)))
+defvjp(anp.maximum,     lambda ans, x, y : lambda g: unbroadcast(y, g, g * balanced_eq(y, ans, x)), argnum=1)
+defvjp(anp.minimum,     lambda ans, x, y : lambda g: unbroadcast(x, g, g * balanced_eq(x, ans, y)))
+defvjp(anp.minimum,     lambda ans, x, y : lambda g: unbroadcast(y, g, g * balanced_eq(y, ans, x)), argnum=1)
+defvjp(anp.fmax,        lambda ans, x, y : lambda g: unbroadcast(x, g, g * balanced_eq(x, ans, y)))
+defvjp(anp.fmax,        lambda ans, x, y : lambda g: unbroadcast(y, g, g * balanced_eq(y, ans, x)), argnum=1)
+defvjp(anp.fmin,        lambda ans, x, y : lambda g: unbroadcast(x, g, g * balanced_eq(x, ans, y)))
+defvjp(anp.fmin,        lambda ans, x, y : lambda g: unbroadcast(y, g, g * balanced_eq(y, ans, x)), argnum=1)
+defvjp(anp.logaddexp,   lambda ans, x, y : lambda g: unbroadcast(x, g, g * anp.exp(x-ans)))
+defvjp(anp.logaddexp,   lambda ans, x, y : lambda g: unbroadcast(y, g, g * anp.exp(y-ans)), argnum=1)
+defvjp(anp.logaddexp2,  lambda ans, x, y : lambda g: unbroadcast(x, g, g * 2**(x-ans)))
+defvjp(anp.logaddexp2,  lambda ans, x, y : lambda g: unbroadcast(y, g, g * 2**(y-ans)), argnum=1)
+defvjp(anp.true_divide, lambda ans, x, y : lambda g: unbroadcast(x, g, g / y))
+defvjp(anp.true_divide, lambda ans, x, y : lambda g: unbroadcast(y, g, - g * x / y**2), argnum=1)
+defvjp(anp.mod,         lambda ans, x, y : lambda g: unbroadcast(x, g, g))
+defvjp(anp.remainder,   lambda ans, x, y : lambda g: unbroadcast(x, g, g))
+defvjp(anp.mod,         lambda ans, x, y : lambda g: unbroadcast(y, g, -g * anp.floor(x/y)), argnum=1)
+defvjp(anp.remainder,   lambda ans, x, y : lambda g: unbroadcast(y, g, -g * anp.floor(x/y)), argnum=1)
 defvjp(anp.power,
-    lambda ans, vs, gvs, x, y : lambda g:
-    unbroadcast(vs, gvs, g * y * x ** anp.where(y, y - 1, 1.)))
+    lambda ans, x, y : lambda g:
+    unbroadcast(x, g, g * y * x ** anp.where(y, y - 1, 1.)))
 defvjp(anp.power,
-    lambda ans, vs, gvs, x, y : lambda g:
-    unbroadcast(vs, gvs, g * anp.log(replace_zero(x, 1.)) * x ** y), argnum=1)
+    lambda ans, x, y : lambda g:
+    unbroadcast(y, g, g * anp.log(replace_zero(x, 1.)) * x ** y), argnum=1)
 
 # ----- Simple grads -----
 
-defvjp(anp.negative, lambda ans, vs, gvs, x: lambda g: -g)
+defvjp(anp.negative, lambda ans, x: lambda g: -g)
 defvjp(anp.abs,
-    lambda ans, vs, gvs, x : lambda g: g * replace_zero(anp.conj(x), 0.) / replace_zero(ans, 1.))
-defvjp(anp.fabs,     lambda ans, vs, gvs, x : lambda g: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defvjp(anp.absolute, lambda ans, vs, gvs, x : lambda g: g * anp.conj(x) / ans)
-defvjp(anp.reciprocal, lambda ans, vs, gvs, x : lambda g: - g / x**2)
-defvjp(anp.exp,    lambda ans, vs, gvs, x : lambda g: ans * g)
-defvjp(anp.exp2,   lambda ans, vs, gvs, x : lambda g: ans * anp.log(2) * g)
-defvjp(anp.expm1,  lambda ans, vs, gvs, x : lambda g: (ans + 1) * g)
-defvjp(anp.log,    lambda ans, vs, gvs, x : lambda g: g / x)
-defvjp(anp.log2,   lambda ans, vs, gvs, x : lambda g: g / x / anp.log(2))
-defvjp(anp.log10,  lambda ans, vs, gvs, x : lambda g: g / x / anp.log(10))
-defvjp(anp.log1p,  lambda ans, vs, gvs, x : lambda g: g / (x + 1))
-defvjp(anp.sin,    lambda ans, vs, gvs, x : lambda g: g * anp.cos(x))
-defvjp(anp.cos,    lambda ans, vs, gvs, x : lambda g: - g * anp.sin(x))
-defvjp(anp.tan,    lambda ans, vs, gvs, x : lambda g: g / anp.cos(x) **2)
-defvjp(anp.arcsin, lambda ans, vs, gvs, x : lambda g: g / anp.sqrt(1 - x**2))
-defvjp(anp.arccos, lambda ans, vs, gvs, x : lambda g:-g / anp.sqrt(1 - x**2))
-defvjp(anp.arctan, lambda ans, vs, gvs, x : lambda g: g / (1 + x**2))
-defvjp(anp.sinh,   lambda ans, vs, gvs, x : lambda g: g * anp.cosh(x))
-defvjp(anp.cosh,   lambda ans, vs, gvs, x : lambda g: g * anp.sinh(x))
-defvjp(anp.tanh,   lambda ans, vs, gvs, x : lambda g: g / anp.cosh(x) **2)
-defvjp(anp.arcsinh, lambda ans, vs, gvs, x : lambda g: g / anp.sqrt(x**2 + 1))
-defvjp(anp.arccosh, lambda ans, vs, gvs, x : lambda g: g / anp.sqrt(x**2 - 1))
-defvjp(anp.arctanh, lambda ans, vs, gvs, x : lambda g: g / (1 - x**2))
-defvjp(anp.rad2deg, lambda ans, vs, gvs, x : lambda g: g / anp.pi * 180.0)
-defvjp(anp.degrees, lambda ans, vs, gvs, x : lambda g: g / anp.pi * 180.0)
-defvjp(anp.deg2rad, lambda ans, vs, gvs, x : lambda g: g * anp.pi / 180.0)
-defvjp(anp.radians, lambda ans, vs, gvs, x : lambda g: g * anp.pi / 180.0)
-defvjp(anp.square,  lambda ans, vs, gvs, x : lambda g: g * 2 * x)
-defvjp(anp.sqrt,    lambda ans, vs, gvs, x : lambda g: g * 0.5 * x**-0.5)
-defvjp(anp.sinc,    lambda ans, vs, gvs, x : lambda g: g * (anp.cos(anp.pi*x)*anp.pi*x - anp.sin(anp.pi*x))/(anp.pi*x**2))
-defvjp(anp.reshape, lambda ans, vs, gvs, x, shape, order=None : lambda g: anp.reshape(g, vs.shape, order=order))
-defvjp(anp.roll,    lambda ans, vs, gvs, x, shift, axis=None  : lambda g: anp.roll(g, -shift, axis=axis))
-defvjp(anp.array_split, lambda ans, vs, gvs, ary, idxs, axis=0 : lambda g: anp.concatenate(g, axis=axis))
-defvjp(anp.split,       lambda ans, vs, gvs, ary, idxs, axis=0 : lambda g: anp.concatenate(g, axis=axis))
-defvjp(anp.vsplit,      lambda ans, vs, gvs, ary, idxs         : lambda g: anp.concatenate(g, axis=0))
-defvjp(anp.hsplit,      lambda ans, vs, gvs, ary, idxs         : lambda g: anp.concatenate(g, axis=1))
-defvjp(anp.dsplit,      lambda ans, vs, gvs, ary, idxs         : lambda g: anp.concatenate(g, axis=2))
-defvjp(anp.ravel,   lambda ans, vs, gvs, x, order=None   : lambda g: anp.reshape(g, vs.shape, order=order))
-defvjp(anp.expand_dims, lambda ans, vs, gvs, x, axis     : lambda g: anp.reshape(g, vs.shape))
-defvjp(anp.squeeze, lambda ans, vs, gvs, x, axis=None    : lambda g: anp.reshape(g, vs.shape))
-defvjp(anp.diag,    lambda ans, vs, gvs, x, k=0          : lambda g: anp.diag(g, k))
-defvjp(anp.flipud,  lambda ans, vs, gvs, x,              : lambda g: anp.flipud(g))
-defvjp(anp.fliplr,  lambda ans, vs, gvs, x,              : lambda g: anp.fliplr(g))
-defvjp(anp.rot90,   lambda ans, vs, gvs, x, k=1          : lambda g: anp.rot90(g, -k))
-defvjp(anp.trace,   lambda ans, vs, gvs, x, offset=0     : lambda g:
+    lambda ans, x : lambda g: g * replace_zero(anp.conj(x), 0.) / replace_zero(ans, 1.))
+defvjp(anp.fabs,     lambda ans, x : lambda g: anp.sign(x) * g)  # fabs doesn't take complex numbers.
+defvjp(anp.absolute, lambda ans, x : lambda g: g * anp.conj(x) / ans)
+defvjp(anp.reciprocal, lambda ans, x : lambda g: - g / x**2)
+defvjp(anp.exp,    lambda ans, x : lambda g: ans * g)
+defvjp(anp.exp2,   lambda ans, x : lambda g: ans * anp.log(2) * g)
+defvjp(anp.expm1,  lambda ans, x : lambda g: (ans + 1) * g)
+defvjp(anp.log,    lambda ans, x : lambda g: g / x)
+defvjp(anp.log2,   lambda ans, x : lambda g: g / x / anp.log(2))
+defvjp(anp.log10,  lambda ans, x : lambda g: g / x / anp.log(10))
+defvjp(anp.log1p,  lambda ans, x : lambda g: g / (x + 1))
+defvjp(anp.sin,    lambda ans, x : lambda g: g * anp.cos(x))
+defvjp(anp.cos,    lambda ans, x : lambda g: - g * anp.sin(x))
+defvjp(anp.tan,    lambda ans, x : lambda g: g / anp.cos(x) **2)
+defvjp(anp.arcsin, lambda ans, x : lambda g: g / anp.sqrt(1 - x**2))
+defvjp(anp.arccos, lambda ans, x : lambda g:-g / anp.sqrt(1 - x**2))
+defvjp(anp.arctan, lambda ans, x : lambda g: g / (1 + x**2))
+defvjp(anp.sinh,   lambda ans, x : lambda g: g * anp.cosh(x))
+defvjp(anp.cosh,   lambda ans, x : lambda g: g * anp.sinh(x))
+defvjp(anp.tanh,   lambda ans, x : lambda g: g / anp.cosh(x) **2)
+defvjp(anp.arcsinh, lambda ans, x : lambda g: g / anp.sqrt(x**2 + 1))
+defvjp(anp.arccosh, lambda ans, x : lambda g: g / anp.sqrt(x**2 - 1))
+defvjp(anp.arctanh, lambda ans, x : lambda g: g / (1 - x**2))
+defvjp(anp.rad2deg, lambda ans, x : lambda g: g / anp.pi * 180.0)
+defvjp(anp.degrees, lambda ans, x : lambda g: g / anp.pi * 180.0)
+defvjp(anp.deg2rad, lambda ans, x : lambda g: g * anp.pi / 180.0)
+defvjp(anp.radians, lambda ans, x : lambda g: g * anp.pi / 180.0)
+defvjp(anp.square,  lambda ans, x : lambda g: g * 2 * x)
+defvjp(anp.sqrt,    lambda ans, x : lambda g: g * 0.5 * x**-0.5)
+defvjp(anp.sinc,    lambda ans, x : lambda g: g * (anp.cos(anp.pi*x)*anp.pi*x - anp.sin(anp.pi*x))/(anp.pi*x**2))
+defvjp(anp.reshape, lambda ans, x, shape, order=None : lambda g: anp.reshape(g, vspace(x).shape, order=order))
+defvjp(anp.roll,    lambda ans, x, shift, axis=None  : lambda g: anp.roll(g, -shift, axis=axis))
+defvjp(anp.array_split, lambda ans, ary, idxs, axis=0 : lambda g: anp.concatenate(g, axis=axis))
+defvjp(anp.split,       lambda ans, ary, idxs, axis=0 : lambda g: anp.concatenate(g, axis=axis))
+defvjp(anp.vsplit,      lambda ans, ary, idxs         : lambda g: anp.concatenate(g, axis=0))
+defvjp(anp.hsplit,      lambda ans, ary, idxs         : lambda g: anp.concatenate(g, axis=1))
+defvjp(anp.dsplit,      lambda ans, ary, idxs         : lambda g: anp.concatenate(g, axis=2))
+defvjp(anp.ravel,   lambda ans, x, order=None   : lambda g: anp.reshape(g, vspace(x).shape, order=order))
+defvjp(anp.expand_dims, lambda ans, x, axis     : lambda g: anp.reshape(g, vspace(x).shape))
+defvjp(anp.squeeze, lambda ans, x, axis=None    : lambda g: anp.reshape(g, vspace(x).shape))
+defvjp(anp.diag,    lambda ans, x, k=0          : lambda g: anp.diag(g, k))
+defvjp(anp.flipud,  lambda ans, x,              : lambda g: anp.flipud(g))
+defvjp(anp.fliplr,  lambda ans, x,              : lambda g: anp.fliplr(g))
+defvjp(anp.rot90,   lambda ans, x, k=1          : lambda g: anp.rot90(g, -k))
+defvjp(anp.trace,   lambda ans, x, offset=0     : lambda g:
                     anp.einsum('ij,...->ij...', anp.eye(x.shape[0], x.shape[1], k=offset), g))
-defvjp(anp.full,    lambda ans, vs, gvs, shape, fill_value, dtype=None : lambda g: anp.sum(g), argnum=1)
-defvjp(anp.triu,    lambda ans, vs, gvs, x, k=0          : lambda g: anp.triu(g, k=k))
-defvjp(anp.tril,    lambda ans, vs, gvs, x, k=0          : lambda g: anp.tril(g, k=k))
-defvjp(anp.clip,    lambda ans, vs, gvs, x, a_min, a_max : lambda g: g * anp.logical_and(ans != a_min, ans != a_max))
-defvjp(anp.swapaxes, lambda ans, vs, gvs, x, axis1, axis2: lambda g: anp.swapaxes(g, axis2, axis1))
-defvjp(anp.moveaxis, lambda ans, vs, gvs, a, source, destination: lambda g:
+defvjp(anp.full,    lambda ans, shape, fill_value, dtype=None : lambda g: anp.sum(g), argnum=1)
+defvjp(anp.triu,    lambda ans, x, k=0          : lambda g: anp.triu(g, k=k))
+defvjp(anp.tril,    lambda ans, x, k=0          : lambda g: anp.tril(g, k=k))
+defvjp(anp.clip,    lambda ans, x, a_min, a_max : lambda g: g * anp.logical_and(ans != a_min, ans != a_max))
+defvjp(anp.swapaxes, lambda ans, x, axis1, axis2: lambda g: anp.swapaxes(g, axis2, axis1))
+defvjp(anp.moveaxis, lambda ans, a, source, destination: lambda g:
                     anp.moveaxis(g, destination, source))
-defvjp(anp.rollaxis, lambda ans, vs, gvs, a, axis, start=0: lambda g: anp.rollaxis(g, start - 1, axis) if start > axis
+defvjp(anp.rollaxis, lambda ans, a, axis, start=0: lambda g: anp.rollaxis(g, start - 1, axis) if start > axis
                                                  else anp.rollaxis(g, start, axis + 1))
-defvjp(anp.real_if_close, lambda ans, vs, gvs, x : lambda g: match_complex(vs, g))
-defvjp(anp.real,   lambda ans, vs, gvs, x   : lambda g: match_complex(vs, g))
-defvjp(anp.imag,   lambda ans, vs, gvs, x   : lambda g: match_complex(vs, -1j * g))
-defvjp(anp.conj,   lambda ans, vs, gvs, x   : lambda g: anp.conj(g))
-defvjp(anp.conjugate, lambda ans, vs, gvs, x: lambda g: anp.conj(g))
-defvjp(anp.angle,  lambda ans, vs, gvs, x   : lambda g: match_complex(vs, g * anp.conj(x * 1j) / anp.abs(x)**2))
-defvjp(anp.where,  lambda ans, vs, gvs, c, x=None, y=None : lambda g: anp.where(c, g, anp.zeros(g.shape)), argnum=1)
-defvjp(anp.where,  lambda ans, vs, gvs, c, x=None, y=None : lambda g: anp.where(c, anp.zeros(g.shape), g), argnum=2)
-defvjp(anp.cross, lambda ans, vs, gvs, a, b, axisa=-1, axisb=-1, axisc=-1, axis=None : lambda g:
+defvjp(anp.real_if_close, lambda ans, x : lambda g: match_complex(x, g))
+defvjp(anp.real,   lambda ans, x   : lambda g: match_complex(x, g))
+defvjp(anp.imag,   lambda ans, x   : lambda g: match_complex(x, -1j * g))
+defvjp(anp.conj,   lambda ans, x   : lambda g: anp.conj(g))
+defvjp(anp.conjugate, lambda ans, x: lambda g: anp.conj(g))
+defvjp(anp.angle,  lambda ans, x   : lambda g: match_complex(x, g * anp.conj(x * 1j) / anp.abs(x)**2))
+defvjp(anp.where,  lambda ans, c, x=None, y=None : lambda g: anp.where(c, g, anp.zeros(g.shape)), argnum=1)
+defvjp(anp.where,  lambda ans, c, x=None, y=None : lambda g: anp.where(c, anp.zeros(g.shape), g), argnum=2)
+defvjp(anp.cross, lambda ans, a, b, axisa=-1, axisb=-1, axisc=-1, axis=None : lambda g:
                   anp.cross(b, g, axisb, axisc, axisa, axis), argnum=0)
-defvjp(anp.cross, lambda ans, vs, gvs, a, b, axisa=-1, axisb=-1, axisc=-1, axis=None : lambda g:
+defvjp(anp.cross, lambda ans, a, b, axisa=-1, axisb=-1, axisc=-1, axis=None : lambda g:
                   anp.cross(g, a, axisc, axisa, axisb, axis), argnum=1)
-defvjp(anp.linspace, lambda ans, vs, gvs, start, stop, num : lambda g: anp.dot(anp.linspace(1.0, 0.0, num), g))
-defvjp(anp.linspace, lambda ans, vs, gvs, start, stop, num : lambda g: anp.dot(anp.linspace(0.0, 1.0, num), g), argnum=1)
+defvjp(anp.linspace, lambda ans, start, stop, num : lambda g: anp.dot(anp.linspace(1.0, 0.0, num), g))
+defvjp(anp.linspace, lambda ans, start, stop, num : lambda g: anp.dot(anp.linspace(0.0, 1.0, num), g), argnum=1)
 
 # ----- Trickier grads -----
 
-def grad_diff(ans, vs, gvs, a, n=1, axis=-1):
+def grad_diff(ans, a, n=1, axis=-1):
+    vs = vspace(a)
+    gvs = vspace(ans)
     nd = len(vs.shape)
     sl1 = [slice(None)]*nd
     sl1[axis] = slice(None, 1)
@@ -148,7 +150,8 @@ def grad_diff(ans, vs, gvs, a, n=1, axis=-1):
 
 defvjp(anp.diff, grad_diff)
 
-def grad_repeat(ans, vs, gvs, x, repeats, axis=None):
+def grad_repeat(ans, x, repeats, axis=None):
+    vs = vspace(x)
     shape = vs.shape
     def vjp(g):
         if axis is None:  # If axis is none, np.repeat() repeats the flattened array.
@@ -164,16 +167,16 @@ def grad_repeat(ans, vs, gvs, x, repeats, axis=None):
 
 defvjp(anp.repeat, grad_repeat)
 
-def grad_tile(ans, vs, gvs, x, reps):
+def grad_tile(ans, x, reps):
     reps = [reps] if anp.isscalar(reps) else reps
     def vjp(g):
         for axis, rep in enumerate(reps):
             g = sum(anp.split(g, rep, axis))
-        return anp.reshape(g, vs.shape)
+        return anp.reshape(g, vspace(x).shape)
     return vjp
 defvjp(anp.tile, grad_tile)
 
-def grad_kron(argnum, ans, vs, gvs, orig_A, orig_B):
+def grad_kron(argnum, ans, orig_A, orig_B):
     # kron has different promotion rules than dot. the reshapes are necessary if
     # and only if (1) orig_B is 1D or (2) orig_A and/or orig_B are 0D
     def vjp(G):
@@ -183,13 +186,13 @@ def grad_kron(argnum, ans, vs, gvs, orig_A, orig_B):
         shape[n-1], shape[n] = shape[n], shape[n-1]
         reshaped_G = anp.swapaxes(anp.reshape(G, shape), n-1, n)
         if argnum == 0:
-            return anp.reshape(anp.tensordot(reshaped_G, B, axes=anp.ndim(B)), vs.shape)
+            return anp.reshape(anp.tensordot(reshaped_G, B, axes=anp.ndim(B)), vspace(orig_A).shape)
         else:
-            return anp.reshape(anp.tensordot(A, reshaped_G, axes=anp.ndim(A)), vs.shape)
+            return anp.reshape(anp.tensordot(A, reshaped_G, axes=anp.ndim(A)), vspace(orig_B).shape)
     return vjp
 defvjps(anp.kron, grad_kron, [0, 1])
 
-def grad_transpose(ans, vs, gvs, x, axes=None):
+def grad_transpose(ans, x, axes=None):
     if axes is not None:
         axes = anp.argsort(axes)
     return lambda g: anp.transpose(g, axes)
@@ -206,25 +209,29 @@ def repeat_to_match_shape(g, vs, axis, keepdims):
     num_reps = onp.prod(onp.array(vs.shape)[axis])
     return anp.reshape(g, shape) + vs.zeros(), num_reps
 
-def grad_np_sum(ans, vs, gvs, x, axis=None, keepdims=False, dtype=None):
+def grad_np_sum(ans, x, axis=None, keepdims=False, dtype=None):
+    vs = vspace(x)
     return lambda g: repeat_to_match_shape(g, vs, axis, keepdims)[0]
 defvjp(anp.sum, grad_np_sum)
 
-def grad_np_mean(ans, vs, gvs, x, axis=None, keepdims=False):
+def grad_np_mean(ans, x, axis=None, keepdims=False):
+    vs = vspace(x)
     def vjp(g):
         g_repeated, num_reps = repeat_to_match_shape(g, vs, axis, keepdims)
         return g_repeated / num_reps
     return vjp
 defvjp(anp.mean, grad_np_mean)
 
-def grad_np_prod(ans, vs, gvs, x, axis=None, keepdims=False): # TODO: Support tuples of axes.
+def grad_np_prod(ans, x, axis=None, keepdims=False): # TODO: Support tuples of axes.
+    vs = vspace(x)
     def vjp(g):
         g_repeated, _ = repeat_to_match_shape(g * ans, vs, axis, keepdims)
         return g_repeated / x
     return vjp
 defvjp(anp.prod, grad_np_prod)
 
-def grad_np_var(ans, vs, gvs, x, axis=None, ddof=0, keepdims=False):
+def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False):
+    vs = vspace(x)
     def vjp(g):
         if vs.iscomplex:
             g = g + 0j
@@ -234,7 +241,8 @@ def grad_np_var(ans, vs, gvs, x, axis=None, ddof=0, keepdims=False):
     return vjp
 defvjp(anp.var, grad_np_var)
 
-def grad_np_std(ans, vs, gvs, x, axis=None, ddof=0, keepdims=False):
+def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False):
+    vs = vspace(x)
     def vjp(g):
         if vs.iscomplex:
             g = g + 0j
@@ -248,7 +256,8 @@ def grad_np_std(ans, vs, gvs, x, axis=None, ddof=0, keepdims=False):
     return vjp
 defvjp(anp.std, grad_np_std)
 
-def grad_chooser(ans, vs, gvs, x, axis=None, keepdims=None):
+def grad_chooser(ans, x, axis=None, keepdims=None):
+    vs = vspace(x)
     def vjp(g):
         """Builds gradient of functions that choose a single item, such as min or max."""
         g_repeated, _ = repeat_to_match_shape(g, vs, axis, keepdims)
@@ -266,7 +275,7 @@ def reverse_axis(x, axis):
     x = x[::-1,...]
     return x.swapaxes(0, axis)
 
-def grad_np_cumsum(ans, vs, gvs, x, axis=None):
+def grad_np_cumsum(ans, x, axis=None):
     def vjp(g):
         if axis:
             return reverse_axis(anp.cumsum(reverse_axis(g, axis), axis), axis)
@@ -275,28 +284,28 @@ def grad_np_cumsum(ans, vs, gvs, x, axis=None):
     return vjp
 defvjp(anp.cumsum, grad_np_cumsum)
 
-def grad_inner(argnum, ans, vs, gvs, A, B):
+def grad_inner(argnum, ans, A, B):
     if anp.ndim(A) == 0 or anp.ndim(B) == 0:
         axes = ([], [])
     else:
         axes = ([A.ndim - 1], [B.ndim - 1])
     if argnum == 0:
-        return lambda G: tensordot_adjoint_0(B, G, axes, vs)
+        return lambda G: tensordot_adjoint_0(B, G, axes, vspace(A))
     elif argnum == 1:
-        return lambda G: tensordot_adjoint_1(A, G, axes, vs)
+        return lambda G: tensordot_adjoint_1(A, G, axes, vspace(B))
 defvjps(anp.inner, grad_inner, [0, 1])
 
-def grad_matmul(argnum, ans, vs, gvs, A, B):
+def grad_matmul(argnum, ans, A, B):
     if anp.ndim(A) == 0 or anp.ndim(B) == 0:
         raise ValueError("Scalar operands are not allowed, use '*' instead")
     elif anp.ndim(A) == 1 or anp.ndim(B) == 1 or (anp.ndim(A) == 2 and anp.ndim(B) == 2):
         axes = ([A.ndim - 1], [max(0, B.ndim - 2)])
         if argnum == 0:
-            return lambda G: tensordot_adjoint_0(B, G, axes, vs)
+            return lambda G: tensordot_adjoint_0(B, G, axes, vspace(A))
         elif argnum == 1:
-            return lambda G: tensordot_adjoint_1(A, G, axes, vs)
+            return lambda G: tensordot_adjoint_1(A, G, axes, vspace(B))
     else:
-        return grad_einsum(argnum + 1, ans, vs, gvs, ("...ij,...jk->...ik", A, B), None)
+        return grad_einsum(argnum + 1, ans, ("...ij,...jk->...ik", A, B), None)
 defvjps(anp.matmul, grad_matmul, [0, 1])
 
 @primitive
@@ -324,14 +333,14 @@ def dot_adjoint_1(A, G, B_vs):
         return swap(onp.tensordot(
             G, A, [range(-A_ndim - B_ndim + 2, -B_ndim + 1), range(A_ndim - 1)]))
 
-defvjp(anp.dot, lambda ans, vs, gvs, A, B: lambda g: dot_adjoint_0(B, g, vs))
-defvjp(anp.dot, lambda ans, vs, gvs, A, B: lambda g: dot_adjoint_1(A, g, vs), 1)
+defvjp(anp.dot, lambda ans, A, B: lambda g: dot_adjoint_0(B, g, vspace(A)))
+defvjp(anp.dot, lambda ans, A, B: lambda g: dot_adjoint_1(A, g, vspace(B)), 1)
 
-defvjp(dot_adjoint_0, lambda ans, vs, gvs, B, g, A_vs: lambda A: dot_adjoint_1(A, g, vs))
-defvjp(dot_adjoint_0, lambda ans, vs, gvs, B, g, *args: lambda A: anp.dot(A, B), 1)
+defvjp(dot_adjoint_0, lambda ans, B, g, A_vs: lambda A: dot_adjoint_1(A, g, vspace(A)))
+defvjp(dot_adjoint_0, lambda ans, B, g, *args: lambda A: anp.dot(A, B), 1)
 
-defvjp(dot_adjoint_1, lambda ans, vs, gvs, A, g, B_vs: lambda B: dot_adjoint_0(B, g, vs))
-defvjp(dot_adjoint_1, lambda ans, vs, gvs, A, g, *args: lambda B: anp.dot(A, B), 1)
+defvjp(dot_adjoint_1, lambda ans, A, g, B_vs: lambda B: dot_adjoint_0(B, g, vspace(A)))
+defvjp(dot_adjoint_1, lambda ans, A, g, *args: lambda B: anp.dot(A, B), 1)
 
 @primitive
 def tensordot_adjoint_0(B, G, axes, A_vs):
@@ -395,19 +404,19 @@ def tensordot_adjoint_1(A, G, axes, B_vs):
             (summed_axes[1][onp.argsort(summed_axes[0])], other_axes[1])))
         return onp.transpose(out, perm)
 
-defvjp(anp.tensordot, lambda ans, vs, gvs, A, B, axes=2: lambda G: tensordot_adjoint_0(B, G, axes, vs))
-defvjp(anp.tensordot, lambda ans, vs, gvs, A, B, axes=2: lambda G: tensordot_adjoint_1(A, G, axes, vs), 1)
+defvjp(anp.tensordot, lambda ans, A, B, axes=2: lambda G: tensordot_adjoint_0(B, G, axes, vspace(A)))
+defvjp(anp.tensordot, lambda ans, A, B, axes=2: lambda G: tensordot_adjoint_1(A, G, axes, vspace(B)), 1)
 
-defvjp(tensordot_adjoint_0, lambda ans, vs, gvs, B, G, axes, A_vs: lambda A: tensordot_adjoint_1(A, G, axes, vs))
-defvjp(tensordot_adjoint_0, lambda ans, vs, gvs, B, G, axes, A_vs: lambda A: anp.tensordot(A, B, axes), 1)
+defvjp(tensordot_adjoint_0, lambda ans, B, G, axes, A_vs: lambda A: tensordot_adjoint_1(A, G, axes, vspace(B)))
+defvjp(tensordot_adjoint_0, lambda ans, B, G, axes, A_vs: lambda A: anp.tensordot(A, B, axes), 1)
 
-defvjp(tensordot_adjoint_1, lambda ans, vs, gvs, A, G, axes, B_vs: lambda B: tensordot_adjoint_0(B, G, axes, vs))
-defvjp(tensordot_adjoint_1, lambda ans, vs, gvs, A, G, axes, B_vs: lambda B: anp.tensordot(A, B, axes), 1)
+defvjp(tensordot_adjoint_1, lambda ans, A, G, axes, B_vs: lambda B: tensordot_adjoint_0(B, G, axes, vspace(A)))
+defvjp(tensordot_adjoint_1, lambda ans, A, G, axes, B_vs: lambda B: anp.tensordot(A, B, axes), 1)
 
-defvjp(anp.outer, lambda ans, vs, gvs, a, b : lambda g: anp.dot(g, b.T))
-defvjp(anp.outer, lambda ans, vs, gvs, a, b : lambda g: anp.dot(a.T, g), argnum=1)
+defvjp(anp.outer, lambda ans, a, b : lambda g: anp.dot(g, b.T))
+defvjp(anp.outer, lambda ans, a, b : lambda g: anp.dot(a.T, g), argnum=1)
 
-def grad_concatenate_args(argnum, ans, vs, gvs, axis_args, kwargs):
+def grad_concatenate_args(argnum, ans, axis_args, kwargs):
     axis, args = axis_args[0], axis_args[1:]
     sizes = [a.shape[axis] for a in args[:argnum]]
     start = sum(sizes[:-1])
@@ -425,7 +434,7 @@ def wrapped_reshape(x, *args, **kwargs):
         return anp.reshape(x, *args, **kwargs)
 setattr(ArrayBox, 'reshape', wrapped_reshape)
 
-def grad_sort(ans, vs, gvs, x, axis=-1, kind='quicksort', order=None):
+def grad_sort(ans, x, axis=-1, kind='quicksort', order=None):
     #TODO: Cast input with np.asanyarray()
     if len(x.shape) > 1:
         raise NotImplementedError(
@@ -435,7 +444,7 @@ def grad_sort(ans, vs, gvs, x, axis=-1, kind='quicksort', order=None):
 defvjp(anp.sort, grad_sort)
 defvjp(anp.msort, grad_sort)  # Until multi-D is allowed, these are the same.
 
-def grad_partition(ans, vs, gvs, x, kth, axis=-1, kind='introselect', order=None):
+def grad_partition(ans, x, kth, axis=-1, kind='introselect', order=None):
     #TODO: Cast input with np.asanyarray()
     if len(x.shape) > 1:
         raise NotImplementedError(
@@ -449,7 +458,7 @@ def unpermuter(g, permutation):
     unsort[permutation] = list(range(len(permutation)))
     return g[unsort]
 
-def grad_reshape_list(ans, vs, gvs, *arys):
+def grad_reshape_list(ans, *arys):
     if len(arys) > 1:
         raise NotImplementedError("Can't handle multiple arguments yet.")
     return lambda g: anp.reshape(g, anp.shape(arys[0]))
@@ -457,7 +466,7 @@ defvjp(anp.atleast_1d, grad_reshape_list)
 defvjp(anp.atleast_2d, grad_reshape_list)
 defvjp(anp.atleast_3d, grad_reshape_list)
 
-def grad_einsum(argnum, ans, vs, gvs, operands_, kwargs):
+def grad_einsum(argnum, ans, operands_, kwargs):
     def vjp(g):
         operands = operands_
         if isinstance(operands[0], string_types):  # using "ijk" convention.
@@ -488,25 +497,26 @@ def grad_einsum(argnum, ans, vs, gvs, operands_, kwargs):
                 new_operands = (g,) + rest_of_ops
 
             new_subscripts = new_input_subs + '->' + subs_wrt
-            return unbroadcast(vs, gvs, anp.einsum(new_subscripts, *new_operands))
+            return unbroadcast(operands_[argnum], ans, anp.einsum(new_subscripts, *new_operands))
         else:  # using (op0, sublist0, op1, sublist1, ..., sublistout) convention
             if len(operands) % 2 == 0:
                 raise NotImplementedError("Need sublistout argument")
             operands = list(operands)
             rest_of_ops = [operands[-1]] + operands[:argnum] + \
                     operands[(argnum+2):-1] + [operands[argnum+1]]
-            return unbroadcast_einsum(vs, gvs, anp.einsum(g, *rest_of_ops), operands[argnum + 1])
+            return unbroadcast_einsum(operands_[argnum], ans, anp.einsum(g, *rest_of_ops), operands[argnum + 1])
     return vjp
 defvjp_argnum(anp.einsum, grad_einsum)
 
 defvjp(anp.diagonal,
-    lambda ans, vs, gvs, A, offset=0, axis1=0, axis2=1 :
+    lambda ans, A, offset=0, axis1=0, axis2=1 :
     lambda g: anp.make_diagonal(g, offset, axis1, axis2))
 defvjp(anp.make_diagonal,
-    lambda ans, vs, gvs, D, offset=0, axis1=0, axis2=1 :
+    lambda ans, D, offset=0, axis1=0, axis2=1 :
     lambda g: anp.diagonal(g, offset, axis1, axis2))
 
-def match_complex(vs, x):
+def match_complex(model, x):
+    vs = vspace(model)
     x_iscomplex = vspace(x).iscomplex
     if x_iscomplex and not vs.iscomplex:
         return anp.real(x)
@@ -515,7 +525,9 @@ def match_complex(vs, x):
     else:
         return x
 
-def unbroadcast(vs, gvs, result, broadcast_idx=0):
+def unbroadcast(x, g, result, broadcast_idx=0):
+    vs = vspace(x)
+    gvs = vspace(g)
     while anp.ndim(result) > vs.ndim:
         result = anp.sum(result, axis=broadcast_idx)
     for axis, size in enumerate(vs.shape):
@@ -525,15 +537,15 @@ def unbroadcast(vs, gvs, result, broadcast_idx=0):
         result = anp.real(result)
     return result
 
-def unbroadcast_einsum(vs, gvs, result, subscript):
+def unbroadcast_einsum(x, ans, result, subscript):
     if Ellipsis not in subscript:
         return result
     elif subscript[0] == Ellipsis:
-        return unbroadcast(vs, gvs, result, 0)
+        return unbroadcast(x, ans, result, 0)
     elif subscript[-1] == Ellipsis:
-        return unbroadcast(vs, gvs, result, -1)
+        return unbroadcast(x, ans, result, -1)
     else:
-        return unbroadcast(vs, gvs, result, subscript.index(Ellipsis))
+        return unbroadcast(x, ans, result, subscript.index(Ellipsis))
 
 def balanced_eq(x, z, y):
     return (x == z) / (1.0 + (x == y))
@@ -543,14 +555,14 @@ def replace_zero(x, val):
 
 # ----- extra functions used internally  -----
 
-def array_from_args_gradmaker(argnum, ans, vs, gvs, args, kwargs):
+def array_from_args_gradmaker(argnum, ans, args, kwargs):
     return lambda g: g[argnum-2]
 defvjp_argnum(anp.array_from_args, array_from_args_gradmaker)
 
-def array_from_scalar_or_array_gradmaker(ans, vs, gvs, array_args, array_kwargs, scarray):
+def array_from_scalar_or_array_gradmaker(ans, array_args, array_kwargs, scarray):
     ndmin = array_kwargs.get('ndmin', 0)
-    if ndmin > vs.ndim:
-        return lambda g: anp.squeeze(g, axis=tuple(range(ndmin - vs.ndim)))
+    if ndmin > vspace(scarray).ndim:
+        return lambda g: anp.squeeze(g, axis=tuple(range(ndmin - vspace(scarray).ndim)))
     else:
         return lambda g: g
 defvjp(anp._array_from_scalar_or_array, array_from_scalar_or_array_gradmaker, argnum=2)
@@ -561,6 +573,6 @@ def untake(x, idx, vs):
         onp.add.at(A, idx, x)
         return A
     return SparseObject(vs, mut_add)
-defvjp(func(ArrayBox.__getitem__), lambda ans, vs, gvs, A, idx: lambda g: untake(g, idx, vs))
-defvjp(untake, lambda ans, vs, gvs, x, idx, _: lambda g: g[idx])
+defvjp(func(ArrayBox.__getitem__), lambda ans, A, idx: lambda g: untake(g, idx, vspace(A)))
+defvjp(untake, lambda ans, x, idx, _: lambda g: g[idx])
 defvjp_is_zero(untake, argnums=(1, 2))

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -18,7 +18,7 @@ nograd_functions = [
     _np.isfinite, _np.isinf, _np.isnan, _np.isneginf, _np.isposinf, _np.allclose, _np.isclose,
     _np.array_equal, _np.array_equiv, _np.greater, _np.greater_equal, _np.less, _np.less_equal,
     _np.equal, _np.not_equal, _np.iscomplexobj, _np.iscomplex, _np.size, _np.isscalar,
-    _np.isreal, _np.zeros_like, _np.ones_like]
+    _np.isreal, _np.zeros_like, _np.ones_like, _np.result_type]
 
 def wrap_namespace(old, new):
     unchanged_types = {float, int, type(None), type}
@@ -139,4 +139,4 @@ def make_diagonal(D, offset=0, axis1=0, axis2=1):
 
 @notrace_primitive
 def metadata(A):
-    return _np.shape(A), _np.ndim(A), _np.iscomplexobj(A)
+    return _np.shape(A), _np.ndim(A), _np.result_type(A), _np.iscomplexobj(A)

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -136,3 +136,7 @@ def make_diagonal(D, offset=0, axis1=0, axis2=1):
     new_array_diag.flags.writeable = True
     new_array_diag[:] = D
     return new_array
+
+@notrace_primitive
+def metadata(A):
+    return _np.shape(A), _np.ndim(A), _np.iscomplexobj(A)

--- a/autograd/scipy/linalg.py
+++ b/autograd/scipy/linalg.py
@@ -7,7 +7,7 @@ from autograd.core import defvjp, defvjps, defvjp_is_zero, defvjp_argnum
 
 wrap_namespace(scipy.linalg.__dict__, globals())  # populates module namespace
 
-defvjp(sqrtm,lambda ans, vs, gvs, A, **kwargs: lambda g: solve_lyapunov(ans, g))
+defvjp(sqrtm,lambda ans, A, **kwargs: lambda g: solve_lyapunov(ans, g))
 
 def _flip(a, trans):
     if anp.iscomplexobj(a):
@@ -15,7 +15,7 @@ def _flip(a, trans):
     else:
         return 'T' if trans in ('N', 0) else 'N'
 
-def grad_solve_triangular(ans, vs, gvs, a, b, trans=0, lower=False, **kwargs):
+def grad_solve_triangular(ans, a, b, trans=0, lower=False, **kwargs):
     tri = anp.tril if (lower ^ (_flip(a, trans) == 'N')) else anp.triu
     transpose = lambda x: x if _flip(a, trans) != 'N' else x.T
     al2d = lambda x: x if x.ndim > 1 else x[...,None]
@@ -25,5 +25,5 @@ def grad_solve_triangular(ans, vs, gvs, a, b, trans=0, lower=False, **kwargs):
     return vjp
 
 defvjp(solve_triangular,grad_solve_triangular)
-defvjp(solve_triangular,lambda ans, vs, gvs, a, b, trans=0, lower=False, **kwargs:
+defvjp(solve_triangular,lambda ans, a, b, trans=0, lower=False, **kwargs:
     lambda g: solve_triangular(a, g, trans=_flip(a, trans), lower=lower), argnum=1)

--- a/autograd/scipy/misc.py
+++ b/autograd/scipy/misc.py
@@ -7,7 +7,7 @@ from autograd.numpy.numpy_vjps import repeat_to_match_shape
 
 logsumexp = primitive(scipy.misc.logsumexp)
 
-def make_grad_logsumexp(ans, vs, gvs, x, axis=None, b=1.0, keepdims=False):
+def make_grad_logsumexp(ans, x, axis=None, b=1.0, keepdims=False):
     def vjp(g):
         g_repeated,   _ = repeat_to_match_shape(g,   vs, axis, keepdims)
         ans_repeated, _ = repeat_to_match_shape(ans, vs, axis, keepdims)

--- a/autograd/scipy/misc.py
+++ b/autograd/scipy/misc.py
@@ -8,9 +8,10 @@ from autograd.numpy.numpy_vjps import repeat_to_match_shape
 logsumexp = primitive(scipy.misc.logsumexp)
 
 def make_grad_logsumexp(ans, x, axis=None, b=1.0, keepdims=False):
+    shape, dtype = anp.shape(x), anp.result_type(x)
     def vjp(g):
-        g_repeated,   _ = repeat_to_match_shape(g,   vs, axis, keepdims)
-        ans_repeated, _ = repeat_to_match_shape(ans, vs, axis, keepdims)
+        g_repeated,   _ = repeat_to_match_shape(g,   shape, dtype, axis, keepdims)
+        ans_repeated, _ = repeat_to_match_shape(ans, shape, dtype, axis, keepdims)
         return g_repeated * b * anp.exp(x - ans_repeated)
     return vjp
 

--- a/autograd/scipy/signal.py
+++ b/autograd/scipy/signal.py
@@ -103,7 +103,7 @@ def flipped_idxs(ndim, axes):
         new_idxs[ax] = slice(None, None, -1)
     return new_idxs
 
-def grad_convolve(argnum, ans, vs, gvs, A, B, axes=None, dot_axes=[(),()], mode='full'):
+def grad_convolve(argnum, ans, A, B, axes=None, dot_axes=[(),()], mode='full'):
     assert mode in ['valid', 'full'], "Grad for mode {0} not yet implemented".format(mode)
     axes, shapes = parse_axes(A.shape, B.shape, axes, dot_axes, mode)
     if argnum == 0:

--- a/autograd/scipy/special.py
+++ b/autograd/scipy/special.py
@@ -16,13 +16,13 @@ multigammaln = primitive(scipy.special.multigammaln)
 
 defvjp_is_zero(gammasgn)
 defvjp_is_zero(polygamma, argnums=(0,))
-defvjp(polygamma, lambda ans, vs, gvs, n, x: lambda g: g * polygamma(n + 1, x), argnum=1)
-defvjp(psi,      lambda ans, vs, gvs, x: lambda g: g * polygamma(1, x))
-defvjp(digamma,  lambda ans, vs, gvs, x: lambda g: g * polygamma(1, x))
-defvjp(gamma,    lambda ans, vs, gvs, x: lambda g: g * ans * psi(x))
-defvjp(gammaln,  lambda ans, vs, gvs, x: lambda g: g * psi(x))
-defvjp(rgamma,   lambda ans, vs, gvs, x: lambda g: g * psi(x) / -gamma(x))
-defvjp(multigammaln,lambda ans, vs, gvs, a, d: lambda g:
+defvjp(polygamma, lambda ans, n, x: lambda g: g * polygamma(n + 1, x), argnum=1)
+defvjp(psi,      lambda ans, x: lambda g: g * polygamma(1, x))
+defvjp(digamma,  lambda ans, x: lambda g: g * polygamma(1, x))
+defvjp(gamma,    lambda ans, x: lambda g: g * ans * psi(x))
+defvjp(gammaln,  lambda ans, x: lambda g: g * psi(x))
+defvjp(rgamma,   lambda ans, x: lambda g: g * psi(x) / -gamma(x))
+defvjp(multigammaln,lambda ans, a, d: lambda g:
     g * np.sum(digamma(np.expand_dims(a, -1) - np.arange(d)/2.), -1))
 defvjp_is_zero(multigammaln,argnums=(1,))
 
@@ -34,22 +34,22 @@ y1 = primitive(scipy.special.y1)
 jn = primitive(scipy.special.jn)
 yn = primitive(scipy.special.yn)
 
-defvjp(j0,lambda ans, vs, gvs, x: lambda g: -g * j1(x))
-defvjp(y0,lambda ans, vs, gvs, x: lambda g: -g * y1(x))
-defvjp(j1,lambda ans, vs, gvs, x: lambda g: g * (j0(x) - jn(2, x)) / 2.0)
-defvjp(y1,lambda ans, vs, gvs, x: lambda g: g * (y0(x) - yn(2, x)) / 2.0)
+defvjp(j0,lambda ans, x: lambda g: -g * j1(x))
+defvjp(y0,lambda ans, x: lambda g: -g * y1(x))
+defvjp(j1,lambda ans, x: lambda g: g * (j0(x) - jn(2, x)) / 2.0)
+defvjp(y1,lambda ans, x: lambda g: g * (y0(x) - yn(2, x)) / 2.0)
 defvjp_is_zero(jn,argnums=(0,))
 defvjp_is_zero(yn,argnums=(0,))
-defvjp(jn,lambda ans, vs, gvs, n, x: lambda g: g * (jn(n - 1, x) - jn(n + 1, x)) / 2.0, argnum=1)
-defvjp(yn,lambda ans, vs, gvs, n, x: lambda g: g * (yn(n - 1, x) - yn(n + 1, x)) / 2.0, argnum=1)
+defvjp(jn,lambda ans, n, x: lambda g: g * (jn(n - 1, x) - jn(n + 1, x)) / 2.0, argnum=1)
+defvjp(yn,lambda ans, n, x: lambda g: g * (yn(n - 1, x) - yn(n + 1, x)) / 2.0, argnum=1)
 
 ### Error Function ###
 inv_root_pi = 0.56418958354775627928
 erf = primitive(scipy.special.erf)
 erfc = primitive(scipy.special.erfc)
 
-defvjp(erf, lambda ans, vs, gvs, x: lambda g:  2.*g*inv_root_pi*np.exp(-x**2))
-defvjp(erfc,lambda ans, vs, gvs, x: lambda g: -2.*g*inv_root_pi*np.exp(-x**2))
+defvjp(erf, lambda ans, x: lambda g:  2.*g*inv_root_pi*np.exp(-x**2))
+defvjp(erfc,lambda ans, x: lambda g: -2.*g*inv_root_pi*np.exp(-x**2))
 
 
 ### Inverse error function ###
@@ -57,12 +57,12 @@ root_pi = 1.7724538509055159
 erfinv = primitive(scipy.special.erfinv)
 erfcinv = primitive(scipy.special.erfcinv)
 
-defvjp(erfinv,lambda ans, vs, gvs, x: lambda g: g * root_pi / 2 * np.exp(erfinv(x)**2))
-defvjp(erfcinv,lambda ans, vs, gvs, x: lambda g: -g * root_pi / 2 * np.exp(erfcinv(x)**2))
+defvjp(erfinv,lambda ans, x: lambda g: g * root_pi / 2 * np.exp(erfinv(x)**2))
+defvjp(erfcinv,lambda ans, x: lambda g: -g * root_pi / 2 * np.exp(erfcinv(x)**2))
 
 ### Logit and Expit ###
 logit = primitive(scipy.special.logit)
 expit = primitive(scipy.special.expit)
 
-defvjp(logit,lambda ans, vs, gvs, x: lambda g: g / ( x * (1 - x)))
-defvjp(expit,lambda ans, vs, gvs, x: lambda g: g * ans * (1 - ans))
+defvjp(logit,lambda ans, x: lambda g: g / ( x * (1 - x)))
+defvjp(expit,lambda ans, x: lambda g: g * ans * (1 - ans))

--- a/autograd/scipy/stats/dirichlet.py
+++ b/autograd/scipy/stats/dirichlet.py
@@ -9,13 +9,13 @@ rvs    = primitive(scipy.stats.dirichlet.rvs)
 pdf    = primitive(scipy.stats.dirichlet.pdf)
 logpdf = primitive(scipy.stats.dirichlet.logpdf)
 
-defvjp(logpdf,lambda ans, vs, gvs, x, alpha: lambda g:
+defvjp(logpdf,lambda ans, x, alpha: lambda g:
               g * (alpha - 1) / x, argnum=0)
-defvjp(logpdf,lambda ans, vs, gvs, x, alpha: lambda g:
+defvjp(logpdf,lambda ans, x, alpha: lambda g:
               g * (digamma(np.sum(alpha)) - digamma(alpha) + np.log(x)), argnum=1)
 
 # Same as log pdf, but multiplied by the pdf (ans).
-defvjp(pdf,lambda ans, vs, gvs, x, alpha: lambda g:
+defvjp(pdf,lambda ans, x, alpha: lambda g:
            g * ans * (alpha - 1) / x, argnum=0)
-defvjp(pdf,lambda ans, vs, gvs, x, alpha: lambda g:
+defvjp(pdf,lambda ans, x, alpha: lambda g:
            g * ans * (digamma(np.sum(alpha)) - digamma(alpha) + np.log(x)), argnum=1)

--- a/autograd/scipy/stats/multivariate_normal.py
+++ b/autograd/scipy/stats/multivariate_normal.py
@@ -50,21 +50,21 @@ def solve(allow_singular):
     else:
         return np.linalg.solve
 
-defvjp(logpdf,lambda ans, vs, gvs, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(vs, gvs, -np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=0)
-defvjp(logpdf,lambda ans, vs, gvs, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(vs, gvs,  np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=1)
-defvjp(logpdf,lambda ans, vs, gvs, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(vs, gvs, -np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)), argnum=2)
+defvjp(logpdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
+       unbroadcast(-np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=0)
+defvjp(logpdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
+       unbroadcast( np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=1)
+defvjp(logpdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
+       unbroadcast(-np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)), argnum=2)
 
 # Same as log pdf, but multiplied by the pdf (ans).
-defvjp(pdf,lambda ans, vs, gvs, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(vs, gvs, -np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=0)
-defvjp(pdf,lambda ans, vs, gvs, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(vs, gvs,  np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=1)
-defvjp(pdf,lambda ans, vs, gvs, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(vs, gvs, -np.reshape(ans * g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)), argnum=2)
+defvjp(pdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
+       unbroadcast(-np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=0)
+defvjp(pdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
+       unbroadcast( np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=1)
+defvjp(pdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
+       unbroadcast(-np.reshape(ans * g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)), argnum=2)
 
 defvjp_is_zero(entropy,argnums=(0,))
-defvjp(entropy,lambda ans, vs, gvs, mean, cov: lambda g:
-       unbroadcast(vs, gvs, 0.5 * g * np.linalg.inv(cov).T), argnum=1)
+defvjp(entropy,lambda ans, mean, cov: lambda g:
+       unbroadcast(0.5 * g * np.linalg.inv(cov).T), argnum=1)

--- a/autograd/scipy/stats/multivariate_normal.py
+++ b/autograd/scipy/stats/multivariate_normal.py
@@ -3,7 +3,7 @@ import scipy.stats
 
 import autograd.numpy as np
 from autograd.core import primitive
-from autograd.numpy.numpy_vjps import unbroadcast
+from autograd.numpy.numpy_vjps import unbroadcast_f
 from autograd.core import primitive, defvjp, defvjps, defvjp_is_zero, defvjp_argnum
 
 
@@ -50,21 +50,21 @@ def solve(allow_singular):
     else:
         return np.linalg.solve
 
-defvjp(logpdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(-np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=0)
-defvjp(logpdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast( np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=1)
-defvjp(logpdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(-np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)), argnum=2)
+defvjp(logpdf, lambda ans, x, mean, cov, allow_singular=False:
+       unbroadcast_f(x, lambda g: -np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=0)
+defvjp(logpdf, lambda ans, x, mean, cov, allow_singular=False:
+       unbroadcast_f(mean, lambda g:  np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=1)
+defvjp(logpdf, lambda ans, x, mean, cov, allow_singular=False:
+       unbroadcast_f(cov, lambda g: -np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)), argnum=2)
 
 # Same as log pdf, but multiplied by the pdf (ans).
-defvjp(pdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(-np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=0)
-defvjp(pdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast( np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=1)
-defvjp(pdf,lambda ans, x, mean, cov, allow_singular=False: lambda g:
-       unbroadcast(-np.reshape(ans * g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)), argnum=2)
+defvjp(pdf, lambda ans, x, mean, cov, allow_singular=False:
+       unbroadcast_f(x, lambda g: -np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=0)
+defvjp(pdf, lambda ans, x, mean, cov, allow_singular=False:
+       unbroadcast_f(mean, lambda g:  np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T), argnum=1)
+defvjp(pdf, lambda ans, x, mean, cov, allow_singular=False:
+       unbroadcast_f(cov, lambda g: -np.reshape(ans * g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)), argnum=2)
 
 defvjp_is_zero(entropy,argnums=(0,))
-defvjp(entropy,lambda ans, mean, cov: lambda g:
-       unbroadcast(0.5 * g * np.linalg.inv(cov).T), argnum=1)
+defvjp(entropy, lambda ans, mean, cov:
+       unbroadcast_f(cov, lambda g: 0.5 * g * np.linalg.inv(cov).T), argnum=1)

--- a/autograd/scipy/stats/norm.py
+++ b/autograd/scipy/stats/norm.py
@@ -10,30 +10,30 @@ cdf = primitive(scipy.stats.norm.cdf)
 logpdf = primitive(scipy.stats.norm.logpdf)
 logcdf = primitive(scipy.stats.norm.logcdf)
 
-defvjp(pdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, -g * ans * (x - loc) / scale**2))
-defvjp(pdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs,  g * ans * (x - loc) / scale**2), argnum=1)
-defvjp(pdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs,  g * ans * (((x - loc)/scale)**2 - 1.0)/scale), argnum=2)
+defvjp(pdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(-g * ans * (x - loc) / scale**2))
+defvjp(pdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast( g * ans * (x - loc) / scale**2), argnum=1)
+defvjp(pdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast( g * ans * (((x - loc)/scale)**2 - 1.0)/scale), argnum=2)
 
-defvjp(cdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs,  g * pdf(x, loc, scale)))
-defvjp(cdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, -g * pdf(x, loc, scale)), argnum=1)
-defvjp(cdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, -g * pdf(x, loc, scale)*(x-loc)/scale), argnum=2)
+defvjp(cdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast( g * pdf(x, loc, scale)))
+defvjp(cdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(-g * pdf(x, loc, scale)), argnum=1)
+defvjp(cdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(-g * pdf(x, loc, scale)*(x-loc)/scale), argnum=2)
 
-defvjp(logpdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, -g * (x - loc) / scale**2))
-defvjp(logpdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs,  g * (x - loc) / scale**2), argnum=1)
-defvjp(logpdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs,  g * (-1.0/scale + (x - loc)**2/scale**3)), argnum=2)
+defvjp(logpdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(-g * (x - loc) / scale**2))
+defvjp(logpdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast( g * (x - loc) / scale**2), argnum=1)
+defvjp(logpdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast( g * (-1.0/scale + (x - loc)**2/scale**3)), argnum=2)
 
-defvjp(logcdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs,  g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))))
-defvjp(logcdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, -g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))), argnum=1)
-defvjp(logcdf,lambda ans, vs, gvs, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, -g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))*(x-loc)/scale), argnum=2)
+defvjp(logcdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast( g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))))
+defvjp(logcdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(-g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))), argnum=1)
+defvjp(logcdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(-g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))*(x-loc)/scale), argnum=2)

--- a/autograd/scipy/stats/norm.py
+++ b/autograd/scipy/stats/norm.py
@@ -3,37 +3,37 @@ from __future__ import absolute_import
 import scipy.stats
 import autograd.numpy as anp
 from autograd.core import primitive, defvjp, defvjps, defvjp_is_zero, defvjp_argnum
-from autograd.numpy.numpy_vjps import unbroadcast
+from autograd.numpy.numpy_vjps import unbroadcast_f
 
 pdf = primitive(scipy.stats.norm.pdf)
 cdf = primitive(scipy.stats.norm.cdf)
 logpdf = primitive(scipy.stats.norm.logpdf)
 logcdf = primitive(scipy.stats.norm.logcdf)
 
-defvjp(pdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(-g * ans * (x - loc) / scale**2))
-defvjp(pdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast( g * ans * (x - loc) / scale**2), argnum=1)
-defvjp(pdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast( g * ans * (((x - loc)/scale)**2 - 1.0)/scale), argnum=2)
+defvjp(pdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(x, lambda g: -g * ans * (x - loc) / scale**2))
+defvjp(pdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(loc, lambda g: g * ans * (x - loc) / scale**2), argnum=1)
+defvjp(pdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(scale, lambda g: g * ans * (((x - loc)/scale)**2 - 1.0)/scale), argnum=2)
 
-defvjp(cdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast( g * pdf(x, loc, scale)))
-defvjp(cdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(-g * pdf(x, loc, scale)), argnum=1)
-defvjp(cdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(-g * pdf(x, loc, scale)*(x-loc)/scale), argnum=2)
+defvjp(cdf, lambda ans, x, loc=-1.0, scale=1.0:
+       unbroadcast_f(x, lambda g: g * pdf(x, loc, scale)))
+defvjp(cdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(loc, lambda g: -g * pdf(x, loc, scale)), argnum=1)
+defvjp(cdf, lambda ans, x, loc=-1.0, scale=1.0:
+       unbroadcast_f(scale, lambda g: -g * pdf(x, loc, scale)*(x-loc)/scale), argnum=2)
 
-defvjp(logpdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(-g * (x - loc) / scale**2))
-defvjp(logpdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast( g * (x - loc) / scale**2), argnum=1)
-defvjp(logpdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast( g * (-1.0/scale + (x - loc)**2/scale**3)), argnum=2)
+defvjp(logpdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(x, lambda g: -g * (x - loc) / scale**2))
+defvjp(logpdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(loc, lambda g: g * (x - loc) / scale**2), argnum=1)
+defvjp(logpdf, lambda ans, x, loc=-1.0, scale=1.0:
+       unbroadcast_f(scale, lambda g: g * (-1.0/scale + (x - loc)**2/scale**3)), argnum=2)
 
-defvjp(logcdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast( g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))))
-defvjp(logcdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(-g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))), argnum=1)
-defvjp(logcdf,lambda ans, x, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(-g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))*(x-loc)/scale), argnum=2)
+defvjp(logcdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(x, lambda g: g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))))
+defvjp(logcdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(loc, lambda g:-g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))), argnum=1)
+defvjp(logcdf, lambda ans, x, loc=0.0, scale=1.0:
+       unbroadcast_f(scale, lambda g:-g * anp.exp(logpdf(x, loc, scale) - logcdf(x, loc, scale))*(x-loc)/scale), argnum=2)

--- a/autograd/scipy/stats/t.py
+++ b/autograd/scipy/stats/t.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import scipy.stats
 import autograd.numpy as np
 from autograd.core import primitive, defvjp, defvjps, defvjp_is_zero, defvjp_argnum
-from autograd.numpy.numpy_vjps import unbroadcast
+from autograd.numpy.numpy_vjps import unbroadcast_f
 from autograd.scipy.special import psi
 
 pdf = primitive(scipy.stats.t.pdf)
@@ -24,31 +24,31 @@ def grad_tlogpdf_df(x, df, loc, scale):
     y = (x - loc)/scale
     return 0.5 * ((y**2 * (df+1))/(df * (y**2 + df)) - np.log(y**2 / df + 1) - 1.0/df -psi(df/2.0) + psi((df + 1)/2.0))
 
-defvjp(pdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(g * ans * grad_tlogpdf_x(    x, df, loc, scale)), argnum=0)
-defvjp(pdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(g * ans * grad_tlogpdf_df(   x, df, loc, scale)), argnum=1)
-defvjp(pdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(g * ans * grad_tlogpdf_loc(  x, df, loc, scale)), argnum=2)
-defvjp(pdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(g * ans * grad_tlogpdf_scale(x, df, loc, scale)), argnum=3)
+defvjp(pdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(x, lambda g: g * ans * grad_tlogpdf_x(    x, df, loc, scale)), argnum=0)
+defvjp(pdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(df, lambda g: g * ans * grad_tlogpdf_df(   x, df, loc, scale)), argnum=1)
+defvjp(pdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(loc, lambda g: g * ans * grad_tlogpdf_loc(  x, df, loc, scale)), argnum=2)
+defvjp(pdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(scale, lambda g: g * ans * grad_tlogpdf_scale(x, df, loc, scale)), argnum=3)
 
-defvjp(cdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast( g * pdf(x, df, loc, scale)), argnum=0)
-defvjp(cdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(-g * pdf(x, df, loc, scale)), argnum=2)
+defvjp(cdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(x, lambda g:  g * pdf(x, df, loc, scale)), argnum=0)
+defvjp(cdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(loc, lambda g: -g * pdf(x, df, loc, scale)), argnum=2)
 # What is the gradient of the cdf wrt the degrees of freedom or scale?  No one knows.
 
-defvjp(logpdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(g * grad_tlogpdf_x(    x, df, loc, scale)), argnum=0)
-defvjp(logpdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(g * grad_tlogpdf_df(   x, df, loc, scale)), argnum=1)
-defvjp(logpdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(g * grad_tlogpdf_loc(  x, df, loc, scale)), argnum=2)
-defvjp(logpdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(g * grad_tlogpdf_scale(x, df, loc, scale)), argnum=3)
+defvjp(logpdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(x, lambda g: g * grad_tlogpdf_x(    x, df, loc, scale)), argnum=0)
+defvjp(logpdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(df, lambda g: g * grad_tlogpdf_df(   x, df, loc, scale)), argnum=1)
+defvjp(logpdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(loc, lambda g: g * grad_tlogpdf_loc(  x, df, loc, scale)), argnum=2)
+defvjp(logpdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(scale, lambda g: g * grad_tlogpdf_scale(x, df, loc, scale)), argnum=3)
 
-defvjp(logcdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast( g * np.exp(logpdf(x, df, loc, scale) - logcdf(x, df, loc, scale))), argnum=0)
-defvjp(logcdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(-g * np.exp(logpdf(x, df, loc, scale) - logcdf(x, df, loc, scale))), argnum=2)
+defvjp(logcdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(x, lambda g:  g * np.exp(logpdf(x, df, loc, scale) - logcdf(x, df, loc, scale))), argnum=0)
+defvjp(logcdf, lambda ans, x, df, loc=0.0, scale=1.0:
+       unbroadcast_f(loc, lambda g: -g * np.exp(logpdf(x, df, loc, scale) - logcdf(x, df, loc, scale))), argnum=2)

--- a/autograd/scipy/stats/t.py
+++ b/autograd/scipy/stats/t.py
@@ -24,31 +24,31 @@ def grad_tlogpdf_df(x, df, loc, scale):
     y = (x - loc)/scale
     return 0.5 * ((y**2 * (df+1))/(df * (y**2 + df)) - np.log(y**2 / df + 1) - 1.0/df -psi(df/2.0) + psi((df + 1)/2.0))
 
-defvjp(pdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, g * ans * grad_tlogpdf_x(    x, df, loc, scale)), argnum=0)
-defvjp(pdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, g * ans * grad_tlogpdf_df(   x, df, loc, scale)), argnum=1)
-defvjp(pdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, g * ans * grad_tlogpdf_loc(  x, df, loc, scale)), argnum=2)
-defvjp(pdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, g * ans * grad_tlogpdf_scale(x, df, loc, scale)), argnum=3)
+defvjp(pdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(g * ans * grad_tlogpdf_x(    x, df, loc, scale)), argnum=0)
+defvjp(pdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(g * ans * grad_tlogpdf_df(   x, df, loc, scale)), argnum=1)
+defvjp(pdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(g * ans * grad_tlogpdf_loc(  x, df, loc, scale)), argnum=2)
+defvjp(pdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(g * ans * grad_tlogpdf_scale(x, df, loc, scale)), argnum=3)
 
-defvjp(cdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs,  g * pdf(x, df, loc, scale)), argnum=0)
-defvjp(cdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, -g * pdf(x, df, loc, scale)), argnum=2)
+defvjp(cdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast( g * pdf(x, df, loc, scale)), argnum=0)
+defvjp(cdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(-g * pdf(x, df, loc, scale)), argnum=2)
 # What is the gradient of the cdf wrt the degrees of freedom or scale?  No one knows.
 
-defvjp(logpdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, g * grad_tlogpdf_x(    x, df, loc, scale)), argnum=0)
-defvjp(logpdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, g * grad_tlogpdf_df(   x, df, loc, scale)), argnum=1)
-defvjp(logpdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, g * grad_tlogpdf_loc(  x, df, loc, scale)), argnum=2)
-defvjp(logpdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, g * grad_tlogpdf_scale(x, df, loc, scale)), argnum=3)
+defvjp(logpdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(g * grad_tlogpdf_x(    x, df, loc, scale)), argnum=0)
+defvjp(logpdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(g * grad_tlogpdf_df(   x, df, loc, scale)), argnum=1)
+defvjp(logpdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(g * grad_tlogpdf_loc(  x, df, loc, scale)), argnum=2)
+defvjp(logpdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(g * grad_tlogpdf_scale(x, df, loc, scale)), argnum=3)
 
-defvjp(logcdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs,  g * np.exp(logpdf(x, df, loc, scale) - logcdf(x, df, loc, scale))), argnum=0)
-defvjp(logcdf,lambda ans, vs, gvs, x, df, loc=0.0, scale=1.0: lambda g:
-       unbroadcast(vs, gvs, -g * np.exp(logpdf(x, df, loc, scale) - logcdf(x, df, loc, scale))), argnum=2)
+defvjp(logcdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast( g * np.exp(logpdf(x, df, loc, scale) - logcdf(x, df, loc, scale))), argnum=0)
+defvjp(logcdf,lambda ans, x, df, loc=0.0, scale=1.0: lambda g:
+       unbroadcast(-g * np.exp(logpdf(x, df, loc, scale) - logcdf(x, df, loc, scale))), argnum=2)

--- a/autograd/test_util.py
+++ b/autograd/test_util.py
@@ -29,6 +29,7 @@ def check_vjp(f, x):
     x_v, y_v = x_vs.randn(), y_vs.randn()
 
     vjp_y = x_vs.covector(vjp(y_vs.covector(y_v)))
+    assert vspace(vjp_y) == x_vs
     vjv_numeric = x_vs.inner_prod(x_v, vjp_y)
     vjv_exact   = y_vs.inner_prod(y_v, jvp(x_v))
     assert scalar_close(vjv_numeric, vjv_exact), \

--- a/autograd/vspace.py
+++ b/autograd/vspace.py
@@ -51,9 +51,3 @@ def vspace(value):
 vspace_mappings = {}
 def register_vspace(vspace_maker, value_type):
     vspace_mappings[value_type] = vspace_maker
-
-def assert_vspace_match(x, expected_vspace):
-    assert expected_vspace == vspace(x), \
-        "\nGrad returned unexpected vector space" \
-        "\nVector space is {}" \
-        "\nExpected        {}".format(vspace(x), expected_vspace)

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -7,7 +7,7 @@ def test_check_vjp_1st_order_fail():
     @primitive
     def foo(x):
         return x * 2.0
-    defvjp(foo, lambda ans, vs, gvs, x : lambda g: g * 2.001)
+    defvjp(foo, lambda ans, x : lambda g: g * 2.001)
 
     assert_raises_regexp(AssertionError,
                          "\(VJP\) check of foo failed",
@@ -17,12 +17,12 @@ def test_check_vjp_2nd_order_fail():
     @primitive
     def foo(x):
         return x * 2.0
-    defvjp(foo, lambda ans, vs, gvs, x : lambda g: bar(g) * 2)
+    defvjp(foo, lambda ans, x : lambda g: bar(g) * 2)
 
     @primitive
     def bar(x):
         return x
-    defvjp(bar, lambda ans, vs, gvs, x : lambda g: g * 1.001)
+    defvjp(bar, lambda ans, x : lambda g: g * 1.001)
 
     assert_raises_regexp(AssertionError,
                          "\(VJP\) check of vjp_foo failed",


### PR DESCRIPTION
These commits make vspaces optional in many parts of the code, and in particular remove them from the VJP signatures. The main motivation is to minimize computational overhead. (We might want to add back some assert statements at some point, since those can be excised from the code easily with zero runtime overhead.)