### PR TITLE
Experiment: combo VJPs

### DIFF
--- a/autograd/container_types.py
+++ b/autograd/container_types.py
@@ -2,7 +2,7 @@ from functools import partial
 from .util import subvals
 from .tracer import Box, register_box, primitive
 from .vspace import VSpace, vspace, register_vspace
-from .core import (defvjp, defvjp_is_zero, defvjp_argnum, SparseObject,
+from .core import (defvjp, defvjp_is_zero, defvjp_argnum, defvjp_argnums, SparseObject,
                    def_linear_wrt_arg, defjvp_argnum)
 
 @primitive
@@ -69,7 +69,7 @@ defvjp_argnum(sequence_extend_left, grad_sequence_extend_left)
 @primitive
 def make_sequence(seq_type, *args):
     return seq_type(args)
-defvjp_argnum(make_sequence, lambda argnum, *args: lambda g: g[argnum - 1])
+defvjp_argnums(make_sequence, lambda argnums, *args: lambda g: [g[argnum - 1] for argnum in argnums])
 
 def fwd_grad_make_sequence(argnum, g, ans, seq_type, *args, **kwargs):
     return container_untake(g, argnum-1, vspace(ans))

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -128,7 +128,7 @@ def defvjp_argnum(fun, vjpmaker):
     primitive_vjps[fun] = first_arg_as_get(vjpmaker)
 
 # TODO(mattjj): do something smarter here given new argnums indexing of
-# primitive_vjps[fun]
+# primitive_vjps[fun]. register all combinations?
 def defvjp_is_zero(fun, argnums=(0,)):
     for argnum in argnums:
         defvjp(fun, zero_vjp(argnum), argnum)
@@ -138,6 +138,8 @@ class first_arg_as_get(object):
     def __init__(self, f):
         self.f = f
     def __getitem__(self, argnum_or_argnums):
+        # TODO(mattjj): should probably just change the spec of defvjp_argnum to
+        # require the provided function to take a tuple of argnums
         if type(argnum_or_argnums) == tuple:
             def vjp_maker(*args, **kwargs):
                 vjps = [self.f(argnum, *args, **kwargs) for argnum in argnum_or_argnums]

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -94,6 +94,7 @@ def zero_vjp(argnum):
 
 primitive_vjps = defaultdict(dict)
 
+# TODO(mattjj): instead of this, make the defaultdict have a defaultdict
 def make_combo_vjp(vjps):
     def combo_vjp(ans, args, kwargs):
         vjps_ = [vjp(ans, args, kwargs) for vjp in vjps]

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -94,7 +94,6 @@ def zero_vjp(argnum):
 
 primitive_vjps = defaultdict(dict)
 
-# TODO(mattjj): instead of this, make the defaultdict have a defaultdict
 def make_combo_vjp(vjps):
     def combo_vjp(ans, args, kwargs):
         vjps_ = [vjp(ans, args, kwargs) for vjp in vjps]

--- a/autograd/tracer.py
+++ b/autograd/tracer.py
@@ -36,8 +36,8 @@ def primitive(f_raw):
         boxed_args, trace, node_constructor = find_top_boxed_args(args)
         if boxed_args:
             argvals = subvals(args, [(argnum, box._value) for argnum, box in boxed_args])
-            parents = [box._node for _     , box in boxed_args]
-            argnums = [argnum    for argnum, _   in boxed_args]
+            parents = tuple(box._node for _     , box in boxed_args)
+            argnums = tuple(argnum    for argnum, _   in boxed_args)
             ans = f_wrapped(*argvals, **kwargs)
             node = node_constructor(ans, f_wrapped, argvals, kwargs, argnums, parents)
             return new_box(ans, trace, node)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -28,10 +28,11 @@ def test_falseyness():
 
 def test_unimplemented_falseyness():
     def remove_grad_definitions(fun):
-        return primitive_vjps[fun]
+        return primitive_vjps.pop(fun, None)
 
     def restore_grad_definitions(fun, grads):
-        primitive_vjps[fun] = grads
+        if grads:
+            primitive_vjps[fun] = grads
 
     grad_defs = remove_grad_definitions(np.iscomplex)
 


### PR DESCRIPTION
I'm **not** recommending we merge this yet! It's just an experiment for now, and I'm opening this PR to track progress.

Check out the change to `backward_pass`. It seems like a good idea to allow users to write VJP functions that evaluate the VJP wrt multiple positional arguments simultaneously, mainly because that can allow for work sharing (instead of always having separate calls).

However, the implementation mechanism here seems to hurt performance a lot:

```
   before     after       ratio
  [fb7eccf6] [c163e986]
+  170.82μs   266.18μs      1.56  bench_core.time_long_backward_pass
+  536.46μs   827.32μs      1.54  bench_core.time_long_grad
+    5.69μs     8.66μs      1.52  bench_core.time_exp_primitive_call_boxed
+  312.14μs   446.58μs      1.43  bench_core.time_long_forward_pass
+     2.02y      2.87y      1.42  bench_rnn.RNNSuite.peakmem_manual_rnn_grad
+  129.84μs   178.60μs      1.38  bench_numpy_vjps.time_tensordot_1_1
+   10.75μs    14.28μs      1.33  bench_core.time_short_backward_pass
+  101.26μs   133.52μs      1.32  bench_numpy_vjps.time_tensordot_0_0
+  274.72ms   349.04ms      1.27  bench_core.time_fan_out_fan_in_forward_pass
+   67.22μs    82.32μs      1.22  bench_numpy_vjps.time_tensordot_0
+   64.15μs    78.47μs      1.22  bench_numpy_vjps.time_dot_0
+  447.36ms   545.34ms      1.22  bench_core.time_fan_out_fan_in_grad
+  116.58μs   136.20μs      1.17  bench_numpy_vjps.time_dot_1_2
+  126.47μs   143.47μs      1.13  bench_numpy_vjps.time_tensordot_1_2
+  281.75ms   319.34ms      1.13  bench_core.time_fan_out_fan_in_backward_pass
+  127.47μs   144.33μs      1.13  bench_numpy_vjps.time_tensordot_1_0
+  118.83μs   134.47μs      1.13  bench_numpy_vjps.time_dot_1_0
+   23.82μs    26.71μs      1.12  bench_core.time_short_forward_pass
+  121.13μs   135.21μs      1.12  bench_numpy_vjps.time_dot_1_1
+  102.82μs   114.14μs      1.11  bench_numpy_vjps.time_tensordot_0_2
+  102.39μs   113.46μs      1.11  bench_numpy_vjps.time_tensordot_0_1
+     1.93y      2.13y      1.11  bench_rnn.RNNSuite.peakmem_rnn_grad
+   69.91μs    77.02μs      1.10  bench_numpy_vjps.time_tensordot_1
-     2.67s      2.23s      0.83  bench_rnn.RNNSuite.time_rnn_grad

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```