### PR TITLE
Add misc package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description='Efficiently computes derivatives of numpy code.',
     author='Dougal Maclaurin and David Duvenaud and Matthew Johnson',
     author_email="maclaurin@physics.harvard.edu, duvenaud@cs.toronto.edu, mattjj@csail.mit.edu",
-    packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats'],
+    packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats', 'autograd.misc'],
     install_requires=['numpy>=1.12', 'scipy>=0.17', 'future>=0.15.2'],
     keywords=['Automatic differentiation', 'backpropagation', 'gradients',
               'machine learning', 'optimization', 'neural networks',


### PR DESCRIPTION
This fixes the flatten benchmarks, which weren't working due to rather confusing import errors.