### PR TITLE
Have travis move into tests folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy nose future
   - pip install -v .
 script: 
-  - cd tests
-  - nosetests
+  - cd tests      # Run from inside tests directory to make sure Autograd has
+  - nosetests     # fully installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ before_install:
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy nose future
   - pip install -v .
-script: nosetests tests
+script: 
+  - cd tests
+  - nosetests


### PR DESCRIPTION
This way tests will fail if for example not all sub-packages have been installed. This is pretty important, tests should certainly fail if we're not even installing the whole of Autograd.

Note that tests fail due to an import error on this branch (as they should), merging https://github.com/HIPS/autograd/pull/294 will fix this.