### PR TITLE
Bench compatibility

### DIFF
--- a/benchmarks/bench_numpy_vjps.py
+++ b/benchmarks/bench_numpy_vjps.py
@@ -3,16 +3,16 @@ from autograd import make_vjp
 import autograd.numpy as np
 import autograd.numpy.random as npr
 
-dot_0 = lambda a, b, g: make_vjp(np.dot)(a, b)[0](g)
+dot_0 = lambda a, b, g: make_vjp(np.dot, argnum=0)(a, b)[0](g)
 dot_1 = lambda a, b, g: make_vjp(np.dot, argnum=1)(a, b)[0](g)
 
-dot_0_0 = lambda a, b, g: make_vjp(dot_0)(a, b, g)[0](a)
-dot_0_1 = lambda a, b, g: make_vjp(dot_0)(a, b, g)[0](a)
-dot_0_2 = lambda a, b, g: make_vjp(dot_0)(a, b, g)[0](a)
+dot_0_0 = lambda a, b, g: make_vjp(dot_0, argnum=0)(a, b, g)[0](a)
+dot_0_1 = lambda a, b, g: make_vjp(dot_0, argnum=1)(a, b, g)[0](a)
+dot_0_2 = lambda a, b, g: make_vjp(dot_0, argnum=2)(a, b, g)[0](a)
 
-dot_1_0 = lambda a, b, g: make_vjp(dot_1)(a, b, g)[0](b)
-dot_1_1 = lambda a, b, g: make_vjp(dot_1)(a, b, g)[0](b)
-dot_1_2 = lambda a, b, g: make_vjp(dot_1)(a, b, g)[0](b)
+dot_1_0 = lambda a, b, g: make_vjp(dot_1, argnum=0)(a, b, g)[0](b)
+dot_1_1 = lambda a, b, g: make_vjp(dot_1, argnum=1)(a, b, g)[0](b)
+dot_1_2 = lambda a, b, g: make_vjp(dot_1, argnum=2)(a, b, g)[0](b)
 
 a = npr.randn(2, 3, 4, 5)
 b = npr.randn(2, 3, 5, 4)
@@ -42,16 +42,16 @@ def time_dot_1_1():
 def time_dot_1_2():
     dot_1_2(a, b, g)
 
-tensordot_0 = lambda A, B, G: make_vjp(np.tensordot)(A, B, 2)[0](G)
+tensordot_0 = lambda A, B, G: make_vjp(np.tensordot, argnum=0)(A, B, 2)[0](G)
 tensordot_1 = lambda A, B, G: make_vjp(np.tensordot, argnum=1)(A, B, 2)[0](G)
 
-tensordot_0_0 = lambda A, B, G: make_vjp(tensordot_0)(A, B, G)[0](A)
-tensordot_0_1 = lambda A, B, G: make_vjp(tensordot_0)(A, B, G)[0](A)
-tensordot_0_2 = lambda A, B, G: make_vjp(tensordot_0)(A, B, G)[0](A)
+tensordot_0_0 = lambda A, B, G: make_vjp(tensordot_0, argnum=0)(A, B, G)[0](A)
+tensordot_0_1 = lambda A, B, G: make_vjp(tensordot_0, argnum=1)(A, B, G)[0](A)
+tensordot_0_2 = lambda A, B, G: make_vjp(tensordot_0, argnum=2)(A, B, G)[0](A)
 
-tensordot_1_0 = lambda A, B, G: make_vjp(tensordot_1)(A, B, G)[0](B)
-tensordot_1_1 = lambda A, B, G: make_vjp(tensordot_1)(A, B, G)[0](B)
-tensordot_1_2 = lambda A, B, G: make_vjp(tensordot_1)(A, B, G)[0](B)
+tensordot_1_0 = lambda A, B, G: make_vjp(tensordot_1, argnum=0)(A, B, G)[0](B)
+tensordot_1_1 = lambda A, B, G: make_vjp(tensordot_1, argnum=1)(A, B, G)[0](B)
+tensordot_1_2 = lambda A, B, G: make_vjp(tensordot_1, argnum=2)(A, B, G)[0](B)
 
 A = npr.randn(2, 3, 5, 4)
 B = npr.randn(5, 4, 2, 3)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description='Efficiently computes derivatives of numpy code.',
     author='Dougal Maclaurin and David Duvenaud and Matthew Johnson',
     author_email="maclaurin@physics.harvard.edu, duvenaud@cs.toronto.edu, mattjj@csail.mit.edu",
-    packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats'],
+    packages=['autograd', 'autograd.numpy', 'autograd.scipy', 'autograd.scipy.stats', 'autograd.misc'],
     install_requires=['numpy>=1.12', 'scipy>=0.17', 'future>=0.15.2'],
     keywords=['Automatic differentiation', 'backpropagation', 'gradients',
               'machine learning', 'optimization', 'neural networks',


### PR DESCRIPTION
I've added some temporary scaffolding to the benchmarks so that they'll run on both master and dev-1.2. I've run a comparison on an AWS instance, the results are:

```
   [master]  [dev-1.2]
-----------------
VSPACE
-----------------
-    2.32μs     1.97μs      0.85  bench_core.time_vspace_float
-    2.29μs     1.97μs      0.86  bench_core.time_vspace_array
-----------------
FLATTEN
-----------------
+  215.12μs     2.19ms     10.18  bench_util.time_flatten
+  665.45μs     3.25ms      4.89  bench_util.time_grad_flatten
-----------------
PRIMITIVE CALL
-----------------
+    1.06μs     1.22μs      1.15  bench_core.time_exp_call
-    3.23μs     2.76μs      0.86  bench_core.time_exp_primitive_call_unboxed
+    3.95μs    10.37μs      2.63  bench_core.time_exp_primitive_call_boxed
-----------------
SHORT FUNCTION
-----------------
+  256.44ns   256.59ns      1.00  bench_core.time_short_fun
+   19.17μs    36.23μs      1.89  bench_core.time_short_forward_pass
-   39.80μs    16.12μs      0.40  bench_core.time_short_backward_pass
+  101.39μs   120.55μs      1.19  bench_core.time_short_grad
-----------------
LONG FUNCTION
-----------------
-  195.26μs   168.39μs      0.86  bench_core.time_long_fun
+  469.11μs   564.76μs      1.20  bench_core.time_long_forward_pass
-  829.99μs   289.17μs      0.35  bench_core.time_long_backward_pass
-    1.30ms   865.72μs      0.67  bench_core.time_long_grad
-----------------
FAN-OUT-FAN-IN
-----------------
+  737.17μs   738.97μs      1.00  bench_core.time_fan_out_fan_in_fun
+  219.23ms   431.44ms      1.97  bench_core.time_fan_out_fan_in_forward_pass
-  598.16ms   359.86ms      0.60  bench_core.time_fan_out_fan_in_backward_pass
-  818.34ms   650.40ms      0.79  bench_core.time_fan_out_fan_in_grad
-----------------
DOT
-----------------
-  215.98μs   102.68μs      0.48  bench_numpy_vjps.time_dot_0
-  209.42μs    98.82μs      0.47  bench_numpy_vjps.time_dot_1

-  247.52μs   158.06μs      0.64  bench_numpy_vjps.time_dot_0_0
-  590.07μs   201.34μs      0.34  bench_numpy_vjps.time_dot_0_1
-  439.64μs   165.21μs      0.38  bench_numpy_vjps.time_dot_0_2
-  600.29μs   186.58μs      0.31  bench_numpy_vjps.time_dot_1_0
-  247.16μs   147.66μs      0.60  bench_numpy_vjps.time_dot_1_1
-  443.19μs   167.62μs      0.38  bench_numpy_vjps.time_dot_1_2
-----------------
TENSORDOT
-----------------

-  113.74μs   109.04μs      0.96  bench_numpy_vjps.time_tensordot_0
+  106.41μs   114.69μs      1.08  bench_numpy_vjps.time_tensordot_1

+  140.90μs   171.59μs      1.22  bench_numpy_vjps.time_tensordot_0_0
-  355.28μs   203.89μs      0.57  bench_numpy_vjps.time_tensordot_0_1
-  302.03μs   182.11μs      0.60  bench_numpy_vjps.time_tensordot_0_2
-  356.77μs   201.06μs      0.56  bench_numpy_vjps.time_tensordot_1_0
+  136.05μs   166.08μs      1.22  bench_numpy_vjps.time_tensordot_1_1
-  291.80μs   173.72μs      0.60  bench_numpy_vjps.time_tensordot_1_2
-----------------
RNN
-----------------
+     1.91y      2.23y      1.16  bench_rnn.RNNSuite.peakmem_manual_rnn_grad
+  952.96ms   960.72ms      1.01  bench_rnn.RNNSuite.time_manual_rnn_grad
-     2.25y      2.07y      0.92  bench_rnn.RNNSuite.peakmem_rnn_grad
-     1.14s      1.04s      0.92  bench_rnn.RNNSuite.time_rnn_grad
-----------------
MISC
-----------------
-   12.32ms    12.22ms      0.99  bench_core.time_no_autograd_control
-    26.63y      1.44y      0.05  bench_mem.peakmem_needless_nodes
```