### PR TITLE
More informative flatten benchmarks

### DIFF
--- a/benchmarks/bench_util.py
+++ b/benchmarks/bench_util.py
@@ -7,17 +7,20 @@ try:
 except ImportError:
     from autograd.util import flatten
 
-def time_flatten():
-    val = {'k':  npr.random((4, 4)),
-           'k2': npr.random((3, 3)),
-           'k3': 3.0,
-           'k4': [1.0, 4.0, 7.0, 9.0],
-           'k5': np.array([4., 5., 6.]),
-           'k6': np.array([[7., 8.], [9., 10.]])}
+val = {'k':  npr.random((4, 4)),
+       'k2': npr.random((3, 3)),
+       'k3': 3.0,
+       'k4': [1.0, 4.0, 7.0, 9.0],
+       'k5': np.array([4., 5., 6.]),
+       'k6': np.array([[7., 8.], [9., 10.]])}
 
-    vect, unflatten = flatten(val)
-    val_recovered = unflatten(vect)
-    vect_2, _ = flatten(val_recovered)
+def time_flatten():
+    flatten(val)
+
+vect, unflatten = flatten(val)
+
+def time_unflatten():
+    unflatten(vect)
 
 # def time_vspace_flatten():
 #     val = {'k':  npr.random((4, 4)),
@@ -29,17 +32,15 @@ def time_flatten():
 
 #     vspace_flatten(val)
 
+def _flatten(v):
+    return np.sum(flatten(v)[0])
+
 def time_grad_flatten():
-    val = {'k':  npr.random((4, 4)),
-           'k2': npr.random((3, 3)),
-           'k3': 3.0,
-           'k4': [1.0, 4.0, 7.0, 9.0],
-           'k5': np.array([4., 5., 6.]),
-           'k6': np.array([[7., 8.], [9., 10.]])}
+    grad(_flatten)(val)
 
-    vect, unflatten = flatten(val)
-    def fun(vec):
-        v = unflatten(vec)
-        return np.sum(v['k5']) + np.sum(v['k6'])
+def _unflatten(vec):
+    v = unflatten(vec)
+    return np.sum(v['k5']) + np.sum(v['k6'])
 
-    grad(fun)(vect)
+def time_grad_unflatten():
+    grad(_unflatten)(vect)


### PR DESCRIPTION
I've separated out the flatten benchmarks to see more precisely where the slow-down is on the new implementation. I get these results on my laptop:
```
    before     after       ratio
  [master] [dev-1.2]
+  101.72μs   394.07μs      3.87  bench_util.time_flatten
+   16.11μs     1.32ms     81.65  bench_util.time_unflatten
+  964.91μs     2.14ms      2.21  bench_util.time_grad_flatten
+  531.38μs     2.69ms      5.06  bench_util.time_grad_unflatten
```