### PR TITLE
Experiment with conditional notrace logic

### DIFF
--- a/autograd/builtins.py
+++ b/autograd/builtins.py
@@ -24,6 +24,8 @@ class SequenceBox(Box):
     def __len__(self): return len(self._value)
     def __add__(self, other): return sequence_extend_right(self, *other)
     def __radd__(self, other): return sequence_extend_left(self, *other)
+    def __contains__(self, elt): return elt in self._value
+    def index(self, elt): return self._value.index(elt)
 SequenceBox.register(tuple_)
 SequenceBox.register(list_)
 
@@ -32,6 +34,7 @@ class DictBox(Box):
     __getitem__= container_take
     def __len__(self): return len(self._value)
     def __iter__(self): return self._value.__iter__()
+    def __contains__(self, elt): return elt in self._value
     def items(self): return list(self.iteritems())
     def keys(self): return list(self.iterkeys())
     def values(self): return list(self.itervalues())

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -237,7 +237,7 @@ class SparseObject(object):
         self.mut_add = mut_add
 VSpace.register(SparseObject, lambda x : x.vs)
 SparseBox.register(SparseObject)
-sparse_object_types = set((SparseObject, SparseBox))
+sparse_object_types = {SparseObject, SparseBox}
 
 # -------------------- core reverse mode grads --------------------
 

--- a/autograd/extend.py
+++ b/autograd/extend.py
@@ -1,5 +1,5 @@
 # Exposes API for extending autograd
-from .tracer import Box, primitive, notrace_primitive
-from .core import (SparseObject, VSpace, vspace,
+from .tracer import Box, primitive, register_notrace, notrace_primitive
+from .core import (SparseObject, VSpace, vspace, VJPNode, JVPNode,
                    defvjp_argnums, defvjp_argnum, defvjp,
                    defjvp_argnums, defjvp_argnum, defjvp, def_linear)

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -8,7 +8,7 @@ from ..util import func
 from .numpy_boxes import ArrayBox
 
 for fun in nograd_functions:
-  register_notrace(JVPNode, fun)
+    register_notrace(JVPNode, fun)
 
 defjvp(func(ArrayBox.__getitem__), 'same')
 defjvp(untake, 'same')

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -1,10 +1,14 @@
 from . import numpy_wrapper as anp
 from .numpy_vjps import (untake, balanced_eq, match_complex, replace_zero,
                          dot_adjoint_0, dot_adjoint_1, tensordot_adjoint_0,
-                         tensordot_adjoint_1)
-from autograd.extend import defjvp, defjvp_argnum, def_linear, vspace
+                         tensordot_adjoint_1, nograd_functions)
+from autograd.extend import (defjvp, defjvp_argnum, def_linear, vspace, JVPNode,
+                             register_notrace)
 from ..util import func
 from .numpy_boxes import ArrayBox
+
+for fun in nograd_functions:
+  register_notrace(JVPNode, fun)
 
 defjvp(func(ArrayBox.__getitem__), 'same')
 defjvp(untake, 'same')

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -5,7 +5,23 @@ import numpy as onp
 from ..util import func
 from . import numpy_wrapper as anp
 from .numpy_boxes import ArrayBox
-from autograd.extend import primitive, vspace, defvjp, defvjp_argnum, SparseObject
+from autograd.extend import (primitive, vspace, defvjp, defvjp_argnum,
+                             SparseObject, VJPNode, register_notrace)
+
+# ----- Non-differentiable functions -----
+
+nograd_functions = [
+    anp.floor, anp.ceil, anp.round, anp.rint, anp.around, anp.fix, anp.trunc, anp.all,
+    anp.any, anp.argmax, anp.argmin, anp.argpartition, anp.argsort, anp.argwhere, anp.nonzero,
+    anp.flatnonzero, anp.count_nonzero, anp.searchsorted, anp.sign, anp.ndim, anp.shape,
+    anp.floor_divide, anp.logical_and, anp.logical_or, anp.logical_not, anp.logical_xor,
+    anp.isfinite, anp.isinf, anp.isnan, anp.isneginf, anp.isposinf, anp.allclose, anp.isclose,
+    anp.array_equal, anp.array_equiv, anp.greater, anp.greater_equal, anp.less, anp.less_equal,
+    anp.equal, anp.not_equal, anp.iscomplexobj, anp.iscomplex, anp.size, anp.isscalar,
+    anp.isreal, anp.zeros_like, anp.ones_like, anp.result_type]
+
+for fun in nograd_functions:
+  register_notrace(VJPNode, fun)
 
 # ----- Functions that are constant w.r.t. continuous inputs -----
 

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -21,7 +21,7 @@ nograd_functions = [
     anp.isreal, anp.zeros_like, anp.ones_like, anp.result_type]
 
 for fun in nograd_functions:
-  register_notrace(VJPNode, fun)
+    register_notrace(VJPNode, fun)
 
 # ----- Functions that are constant w.r.t. continuous inputs -----
 

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -11,24 +11,12 @@ def wrap_intdtype(cls):
         __new__ = notrace_primitive(cls.__new__)
     return IntdtypeSubclass
 
-nograd_functions = [
-    _np.floor, _np.ceil, _np.round, _np.rint, _np.around, _np.fix, _np.trunc, _np.all,
-    _np.any, _np.argmax, _np.argmin, _np.argpartition, _np.argsort, _np.argwhere, _np.nonzero,
-    _np.flatnonzero, _np.count_nonzero, _np.searchsorted, _np.sign, _np.ndim, _np.shape,
-    _np.floor_divide, _np.logical_and, _np.logical_or, _np.logical_not, _np.logical_xor,
-    _np.isfinite, _np.isinf, _np.isnan, _np.isneginf, _np.isposinf, _np.allclose, _np.isclose,
-    _np.array_equal, _np.array_equiv, _np.greater, _np.greater_equal, _np.less, _np.less_equal,
-    _np.equal, _np.not_equal, _np.iscomplexobj, _np.iscomplex, _np.size, _np.isscalar,
-    _np.isreal, _np.zeros_like, _np.ones_like, _np.result_type]
-
 def wrap_namespace(old, new):
     unchanged_types = {float, int, type(None), type}
     int_types = {_np.int, _np.int8, _np.int16, _np.int32, _np.int64, _np.integer}
     function_types = {_np.ufunc, types.FunctionType, types.BuiltinFunctionType}
     for name, obj in old.items():
-        if obj in nograd_functions:
-            new[name] = notrace_primitive(obj)
-        elif type(obj) in function_types:
+        if type(obj) in function_types:
             new[name] = primitive(obj)
         elif type(obj) is type and obj in int_types:
             new[name] = wrap_intdtype(obj)


### PR DESCRIPTION
I'm playing around with how we can make trace-dropping logic conditional on the trace type. The main change here is in tracer.py:`primitive`.

We could tweak this implementation a bit to get back the drop-parent-on-zero-vjp behavior: basically in `primitive` we could filter the parents/argnums lists according to some trace-type-specific side information (like the current `notrace_primitives[node_constructor]` set), then only create a new box if the parents list is nonempty.

There are a couple unrelated changes here in builtins.py to do with adding methods to those Box types.

I ran `asv continuous dev-1.2 experiment-conditional-notrace` and didn't see any significant changes. (I ran it twice and each time there were a couple of minor changes, but they were different across the two runs, so I suspect there's just some variance in those benchmarks.)

Any thoughts on the implementation? Should I try out the argnum-filtering version?