### PR TITLE
Added keyword arguments for gradient tolerance to the check_grads function

### DIFF
--- a/autograd/util.py
+++ b/autograd/util.py
@@ -47,13 +47,15 @@ def check_equivalent(A, B, rtol=RTOL, atol=ATOL):
         "Diffs are:\n{}.\nanalytic is:\n{}.\nnumeric is:\n{}.".format(
             A_flat - B_flat, A_flat, B_flat)
 
-def check_grads(fun, *args, rtol=RTOL, atol=ATOL):
+def check_grads(fun, *args, **kwargs):
     if not args:
         raise Exception("No args given")
+
     exact = tuple([grad(fun, i)(*args) for i in range(len(args))])
     args = [float(x) if isinstance(x, int) else x for x in args]
     numeric = nd(fun, *args)
-    check_equivalent(exact, numeric, rtol, atol)
+    check_equivalent(exact, numeric,
+                     kwargs.get("rtol", RTOL), kwargs.get("atol", ATOL))
 
 def to_scalar(x):
     if isinstance(getval(x), list)  or isinstance(getval(x), tuple):

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -47,13 +47,13 @@ def check_equivalent(A, B, rtol=RTOL, atol=ATOL):
         "Diffs are:\n{}.\nanalytic is:\n{}.\nnumeric is:\n{}.".format(
             A_flat - B_flat, A_flat, B_flat)
 
-def check_grads(fun, *args):
+def check_grads(fun, *args, rtol=RTOL, atol=ATOL):
     if not args:
         raise Exception("No args given")
     exact = tuple([grad(fun, i)(*args) for i in range(len(args))])
     args = [float(x) if isinstance(x, int) else x for x in args]
     numeric = nd(fun, *args)
-    check_equivalent(exact, numeric)
+    check_equivalent(exact, numeric, rtol, atol)
 
 def to_scalar(x):
     if isinstance(getval(x), list)  or isinstance(getval(x), tuple):


### PR DESCRIPTION
The quick_grad_check function does allow specifying the tolerance but it checks at a random point. The check_grads allows me to specify where I want to check the gradient but does currently not allow setting tolerances.

Adding the relative and absolute tolerances as additional keyword arguments adds this option and shouldn't break anything else.