### PR TITLE
Implement VJPs for Poisson CDF and PMF

### DIFF
--- a/autograd/scipy/stats/__init__.py
+++ b/autograd/scipy/stats/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from . import norm
+from . import poisson
 from . import t
 
 # Try block needed in case the user has an

--- a/autograd/scipy/stats/poisson.py
+++ b/autograd/scipy/stats/poisson.py
@@ -4,6 +4,7 @@ import autograd.numpy as np
 import scipy.stats
 
 from autograd.core import primitive
+from autograd.numpy.numpy_grads import unbroadcast
 
 cdf = primitive(scipy.stats.poisson.cdf)
 logpmf = primitive(scipy.stats.poisson.logpmf)
@@ -12,6 +13,6 @@ pmf = primitive(scipy.stats.poisson.pmf)
 def grad_poisson_logpdf(k, mu):
     return np.where(k % 1 == 0, k / mu - 1, 0)
 
-cdf.defvjp(lambda g, ans, vs, gvs, k, mu: g * -pmf(np.floor(k), mu), argnum=1)
-logpmf.defvjp(lambda g, ans, vs, gvs, k, mu: g * grad_poisson_logpdf(k, mu), argnum=1)
-pmf.defvjp(lambda g, ans, vs, gvs, k, mu: g * ans * grad_poisson_logpdf(k, mu), argnum=1)
+cdf.defvjp(lambda g, ans, vs, gvs, k, mu: unbroadcast(vs, gvs, g * -pmf(np.floor(k), mu)), argnum=1)
+logpmf.defvjp(lambda g, ans, vs, gvs, k, mu: unbroadcast(vs, gvs, g * grad_poisson_logpdf(k, mu)), argnum=1)
+pmf.defvjp(lambda g, ans, vs, gvs, k, mu: unbroadcast(vs, gvs, g * ans * grad_poisson_logpdf(k, mu)), argnum=1)

--- a/autograd/scipy/stats/poisson.py
+++ b/autograd/scipy/stats/poisson.py
@@ -10,9 +10,9 @@ cdf = primitive(scipy.stats.poisson.cdf)
 logpmf = primitive(scipy.stats.poisson.logpmf)
 pmf = primitive(scipy.stats.poisson.pmf)
 
-def grad_poisson_logpdf(k, mu):
+def grad_poisson_logpmf(k, mu):
     return np.where(k % 1 == 0, k / mu - 1, 0)
 
 cdf.defvjp(lambda g, ans, vs, gvs, k, mu: unbroadcast(vs, gvs, g * -pmf(np.floor(k), mu)), argnum=1)
-logpmf.defvjp(lambda g, ans, vs, gvs, k, mu: unbroadcast(vs, gvs, g * grad_poisson_logpdf(k, mu)), argnum=1)
-pmf.defvjp(lambda g, ans, vs, gvs, k, mu: unbroadcast(vs, gvs, g * ans * grad_poisson_logpdf(k, mu)), argnum=1)
+logpmf.defvjp(lambda g, ans, vs, gvs, k, mu: unbroadcast(vs, gvs, g * grad_poisson_logpmf(k, mu)), argnum=1)
+pmf.defvjp(lambda g, ans, vs, gvs, k, mu: unbroadcast(vs, gvs, g * ans * grad_poisson_logpmf(k, mu)), argnum=1)

--- a/autograd/scipy/stats/poisson.py
+++ b/autograd/scipy/stats/poisson.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+import autograd.numpy as np
+import scipy.stats
+
+from autograd.core import primitive
+from autograd.scipy.special import digamma, gamma
+
+cdf = primitive(scipy.stats.poisson.cdf)
+logpmf = primitive(scipy.stats.poisson.logpmf)
+pmf = primitive(scipy.stats.poisson.pmf)
+
+def grad_poisson_logpdf(k, mu):
+    return np.where(k % 1 == 0, k / mu - 1, 0)
+
+cdf.defvjp(lambda g, ans, vs, gvs, k, mu: g * -pmf(np.floor(k), mu), argnum=1)
+logpmf.defvjp(lambda g, ans, vs, gvs, k, mu: g * grad_poisson_logpdf(k, mu), argnum=1)
+pmf.defvjp(lambda g, ans, vs, gvs, k, mu: g * ans * grad_poisson_logpdf(k, mu), argnum=1)

--- a/autograd/scipy/stats/poisson.py
+++ b/autograd/scipy/stats/poisson.py
@@ -4,7 +4,6 @@ import autograd.numpy as np
 import scipy.stats
 
 from autograd.core import primitive
-from autograd.scipy.special import digamma, gamma
 
 cdf = primitive(scipy.stats.poisson.cdf)
 logpmf = primitive(scipy.stats.poisson.logpmf)

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -48,6 +48,14 @@ else:
     def test_norm_logpdf_broadcast(): combo_check(stats.norm.logpdf, [0,1,2], [R(4,3)], [R(1,3)], [R(4,1)**2 + 1.1])
     def test_norm_logcdf_broadcast(): combo_check(stats.norm.logcdf, [0,1,2], [R(4,3)], [R(1,3)], [R(4,1)**2 + 1.1])
 
+    def test_poisson_cdf():    combo_check(stats.poisson.cdf,    [1], [np.round(R(4)**2)], [R(4)**2])
+    def test_poisson_logpmf(): combo_check(stats.poisson.logpmf, [1], [np.round(R(4)**2)], [R(4)**2])
+    def test_poisson_pmf():    combo_check(stats.poisson.pmf,    [1], [np.round(R(4)**2)], [R(4)**2])
+
+    def test_poisson_cdf_broadcast():    combo_check(stats.poisson.cdf,    [1], [np.round(R(4, 3)**2)], [R(4, 3)**2])
+    def test_poisson_logpmf_broadcast(): combo_check(stats.poisson.logpmf, [1], [np.round(R(4, 3)**2)], [R(4, 3)**2])
+    def test_poisson_pmf_broadcast():    combo_check(stats.poisson.pmf,    [1], [np.round(R(4, 3)**2)], [R(4, 3)**2])
+
     def test_t_pdf():    combo_check(stats.t.pdf,    [0,1,2,3], [R(4)], [R(4)**2 + 2.1], [R(4)], [R(4)**2 + 2.1])
     def test_t_cdf():    combo_check(stats.t.cdf,    [0,2],     [R(4)], [R(4)**2 + 2.1], [R(4)], [R(4)**2 + 2.1])
     def test_t_logpdf(): combo_check(stats.t.logpdf, [0,1,2,3], [R(4)], [R(4)**2 + 2.1], [R(4)], [R(4)**2 + 2.1])

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -48,13 +48,13 @@ else:
     def test_norm_logpdf_broadcast(): combo_check(stats.norm.logpdf, [0,1,2], [R(4,3)], [R(1,3)], [R(4,1)**2 + 1.1])
     def test_norm_logcdf_broadcast(): combo_check(stats.norm.logcdf, [0,1,2], [R(4,3)], [R(1,3)], [R(4,1)**2 + 1.1])
 
-    def test_poisson_cdf():    combo_check(stats.poisson.cdf,    [1], [np.round(R(4)**2)], [R(4)**2])
-    def test_poisson_logpmf(): combo_check(stats.poisson.logpmf, [1], [np.round(R(4)**2)], [R(4)**2])
-    def test_poisson_pmf():    combo_check(stats.poisson.pmf,    [1], [np.round(R(4)**2)], [R(4)**2])
+    def test_poisson_cdf():    combo_check(stats.poisson.cdf,    [1], [np.round(R(4)**2)], [R(4)**2 + 1.1])
+    def test_poisson_logpmf(): combo_check(stats.poisson.logpmf, [1], [np.round(R(4)**2)], [R(4)**2 + 1.1])
+    def test_poisson_pmf():    combo_check(stats.poisson.pmf,    [1], [np.round(R(4)**2)], [R(4)**2 + 1.1])
 
-    def test_poisson_cdf_broadcast():    combo_check(stats.poisson.cdf,    [1], [np.round(R(4, 3)**2)], [R(4, 3)**2])
-    def test_poisson_logpmf_broadcast(): combo_check(stats.poisson.logpmf, [1], [np.round(R(4, 3)**2)], [R(4, 3)**2])
-    def test_poisson_pmf_broadcast():    combo_check(stats.poisson.pmf,    [1], [np.round(R(4, 3)**2)], [R(4, 3)**2])
+    def test_poisson_cdf_broadcast():    combo_check(stats.poisson.cdf,    [1], [np.round(R(4, 3)**2)], [R(4, 1)**2 + 1.1])
+    def test_poisson_logpmf_broadcast(): combo_check(stats.poisson.logpmf, [1], [np.round(R(4, 3)**2)], [R(4, 1)**2 + 1.1])
+    def test_poisson_pmf_broadcast():    combo_check(stats.poisson.pmf,    [1], [np.round(R(4, 3)**2)], [R(4, 1)**2 + 1.1])
 
     def test_t_pdf():    combo_check(stats.t.pdf,    [0,1,2,3], [R(4)], [R(4)**2 + 2.1], [R(4)], [R(4)**2 + 2.1])
     def test_t_cdf():    combo_check(stats.t.cdf,    [0,2],     [R(4)], [R(4)**2 + 2.1], [R(4)], [R(4)**2 + 2.1])


### PR DESCRIPTION
This PR implements VJPs for the Poisson CDF and PMF w.r.t. the rate parameter (`mu` in SciPy).