### PR TITLE
Add metaclasses so that more isinstance checks work.

### DIFF
--- a/autograd/builtins.py
+++ b/autograd/builtins.py
@@ -1,4 +1,5 @@
 import itertools
+from future.utils import with_metaclass
 from .util import subvals
 from .extend import (Box, primitive, notrace_primitive, VSpace, vspace,
                      SparseObject, defvjp, defvjp_argnum, defjvp, defjvp_argnum)
@@ -88,23 +89,21 @@ defjvp_argnum(make_sequence, fwd_grad_make_sequence)
 class TupleMeta(type_):
     def __instancecheck__(self, instance):
         return isinstance(instance, tuple_)
-class tuple(tuple_):
-    __metaclass__ = TupleMeta
+class tuple(with_metaclass(TupleMeta, tuple_)):
     def __new__(cls, xs):
         return make_sequence(tuple_, *xs)
 
 class ListMeta(type_):
     def __instancecheck__(self, instance):
         return isinstance(instance, list_)
-class list(list_):
-    __metaclass__ = ListMeta
+class list(with_metaclass(ListMeta, list_)):
     def __new__(cls, xs):
         return make_sequence(list_,  *xs)
 
 class DictMeta(type_):
     def __instancecheck__(self, instance):
         return isinstance(instance, dict_)
-class dict(dict_):
+class dict(with_metaclass(DictMeta, dict_)):
     __metaclass__ = DictMeta
     def __new__(cls, args, **kwargs):
         keys, vals = zip(*itertools.chain(args, kwargs.items()))

--- a/autograd/builtins.py
+++ b/autograd/builtins.py
@@ -84,14 +84,28 @@ def fwd_grad_make_sequence(argnum, g, ans, seq_type, *args, **kwargs):
 
 defjvp_argnum(make_sequence, fwd_grad_make_sequence)
 
+
+class TupleMeta(type_):
+    def __instancecheck__(self, instance):
+        return isinstance(instance, tuple_)
 class tuple(tuple_):
+    __metaclass__ = TupleMeta
     def __new__(cls, xs):
         return make_sequence(tuple_, *xs)
+
+class ListMeta(type_):
+    def __instancecheck__(self, instance):
+        return isinstance(instance, list_)
 class list(list_):
+    __metaclass__ = ListMeta
     def __new__(cls, xs):
         return make_sequence(list_,  *xs)
 
+class DictMeta(type_):
+    def __instancecheck__(self, instance):
+        return isinstance(instance, dict_)
 class dict(dict_):
+    __metaclass__ = DictMeta
     def __new__(cls, args, **kwargs):
         keys, vals = zip(*itertools.chain(args, kwargs.items()))
         return _make_dict(keys, list(vals))

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -102,6 +102,7 @@ def test_make_dict():
 def test_isinstance():
     def fun(x):
         assert ag_isinstance(x, dict)
+        assert ag_isinstance(x, ag_dict)
         return x['x']
     fun({'x': 1.})
     grad(fun)({'x': 1.})

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -72,6 +72,7 @@ def test_make_list():
 def test_isinstance():
     def fun(x):
         assert ag_isinstance(x, list)
+        assert ag_isinstance(x, ag_list)
         return x[0]
     fun([1., 2., 3.])
     grad(fun)([1., 2., 3.])

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -58,6 +58,7 @@ def test_nested_higher_order():
 def test_isinstance():
     def fun(x):
         assert ag_isinstance(x, tuple)
+        assert ag_isinstance(x, ag_tuple)
         return x[0]
     fun((1., 2., 3.))
     grad(fun)((1., 2., 3.))


### PR DESCRIPTION
As a result, users can write code like this:

```python
from autograd.builtins import list
...
    assert isinstance([], list)
```

without having to keep autograd's `autograd.builtins.list` separate (since `isinstance([], autorad.builtins.list)` is `False` before this commit, but `True` now).

I think this is basically [Python's intended use case for overriding these methods in the metaclass](https://docs.python.org/2/reference/datamodel.html#customizing-instance-and-subclass-checks).