### PR TITLE
Implement VJPs for χ² CDF and PDF

### DIFF
--- a/autograd/scipy/stats/__init__.py
+++ b/autograd/scipy/stats/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from . import chi2
 from . import norm
 from . import poisson
 from . import t

--- a/autograd/scipy/stats/chi2.py
+++ b/autograd/scipy/stats/chi2.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import autograd.numpy as np
 import scipy.stats

--- a/autograd/scipy/stats/chi2.py
+++ b/autograd/scipy/stats/chi2.py
@@ -13,6 +13,6 @@ pdf = primitive(scipy.stats.chi2.pdf)
 def grad_chi2_logpdf(x, df):
     return np.where(df % 1 == 0, (df - x - 2) / (2 * x), 0)
 
-defvjp(cdf, lambda ans, x, df: unbroadcast_f(x, lambda g: g * np.power(2, -df/2) * np.exp(-x/2) * np.power(x, df/2 - 1) / gamma(df/2)), argnums=[0])
+defvjp(cdf, lambda ans, x, df: unbroadcast_f(x, lambda g: g * np.power(2., -df/2) * np.exp(-x/2) * np.power(x, df/2 - 1) / gamma(df/2)), argnums=[0])
 defvjp(logpdf, lambda ans, x, df: unbroadcast_f(x, lambda g: g * grad_chi2_logpdf(x, df)), argnums=[0])
 defvjp(pdf, lambda ans, x, df: unbroadcast_f(x, lambda g: g * ans * grad_chi2_logpdf(x, df)), argnums=[0])

--- a/autograd/scipy/stats/chi2.py
+++ b/autograd/scipy/stats/chi2.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+import autograd.numpy as np
+import scipy.stats
+from autograd.extend import primitive, defvjp
+from autograd.numpy.numpy_vjps import unbroadcast_f
+from autograd.scipy.special import gamma
+
+cdf = primitive(scipy.stats.chi2.cdf)
+logpdf = primitive(scipy.stats.chi2.logpdf)
+pdf = primitive(scipy.stats.chi2.pdf)
+
+def grad_chi2_logpdf(x, df):
+    return np.where(df % 1 == 0, (df - x - 2) / (2 * x), 0)
+
+defvjp(cdf, lambda ans, x, df: unbroadcast_f(x, lambda g: g * np.power(2, -df/2) * np.exp(-x/2) * np.power(x, df/2 - 1) / gamma(df/2)), argnums=[0])
+defvjp(logpdf, lambda ans, x, df: unbroadcast_f(x, lambda g: g * grad_chi2_logpdf(x, df)), argnums=[0])
+defvjp(pdf, lambda ans, x, df: unbroadcast_f(x, lambda g: g * ans * grad_chi2_logpdf(x, df)), argnums=[0])

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -42,6 +42,10 @@ else:
         return symmetrized_fun
 
     ### Stats ###
+    def test_chi2_pdf():    combo_check(stats.chi2.pdf,    [0])([R(4)**2 + 1.1], [1, 2, 3])
+    def test_chi2_cdf():    combo_check(stats.chi2.cdf,    [0])([R(4)**2 + 1.1], [1, 2, 3])
+    def test_chi2_logpdf(): combo_check(stats.chi2.logpdf, [0])([R(4)**2 + 1.1], [1, 2, 3])
+
     def test_norm_pdf():    combo_check(stats.norm.pdf,    [0,1,2])([R(4)], [R(4)], [R(4)**2 + 1.1])
     def test_norm_cdf():    combo_check(stats.norm.cdf,    [0,1,2])([R(4)], [R(4)], [R(4)**2 + 1.1])
     def test_norm_logpdf(): combo_check(stats.norm.logpdf, [0,1,2])([R(4)], [R(4)], [R(4)**2 + 1.1])


### PR DESCRIPTION
This PR implements VJPs for the χ² CDF and PDF w.r.t. its argument (`x` in SciPy).