### PR TITLE
Implement VJPs for gamma CDF and PDF

### DIFF
--- a/autograd/scipy/stats/__init__.py
+++ b/autograd/scipy/stats/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from . import gamma
 from . import norm
 from . import poisson
 from . import t

--- a/autograd/scipy/stats/gamma.py
+++ b/autograd/scipy/stats/gamma.py
@@ -4,8 +4,9 @@ import autograd.numpy as np
 import scipy.stats
 from autograd.extend import primitive, defvjp
 from autograd.numpy.numpy_vjps import unbroadcast_f
-from autograd.scipy.special import psi
+from autograd.scipy.special import gamma, psi
 
+cdf = primitive(scipy.stats.gamma.cdf)
 logpdf = primitive(scipy.stats.gamma.logpdf)
 pdf = primitive(scipy.stats.gamma.pdf)
 
@@ -15,6 +16,7 @@ def grad_gamma_logpdf_arg0(x, a):
 def grad_gamma_logpdf_arg1(x, a):
     return np.log(x) - psi(a)
 
+defvjp(cdf, lambda ans, x, a: unbroadcast_f(x, lambda g: g * np.exp(-x) * np.power(x, a-1) / gamma(a)), argnums=[0])
 defvjp(logpdf,
        lambda ans, x, a: unbroadcast_f(x, lambda g: g * grad_gamma_logpdf_arg0(x, a)),
        lambda ans, x, a: unbroadcast_f(a, lambda g: g * grad_gamma_logpdf_arg1(x, a)))

--- a/autograd/scipy/stats/gamma.py
+++ b/autograd/scipy/stats/gamma.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+
+import autograd.numpy as np
+import scipy.stats
+from autograd.extend import primitive, defvjp
+from autograd.numpy.numpy_vjps import unbroadcast_f
+from autograd.scipy.special import psi
+
+logpdf = primitive(scipy.stats.gamma.logpdf)
+pdf = primitive(scipy.stats.gamma.pdf)
+
+def grad_gamma_logpdf_arg0(x, a):
+    return (a - x - 1) / x
+
+def grad_gamma_logpdf_arg1(x, a):
+    return np.log(x) - psi(a)
+
+defvjp(logpdf,
+       lambda ans, x, a: unbroadcast_f(x, lambda g: g * grad_gamma_logpdf_arg0(x, a)),
+       lambda ans, x, a: unbroadcast_f(a, lambda g: g * grad_gamma_logpdf_arg1(x, a)))
+defvjp(pdf,
+       lambda ans, x, a: unbroadcast_f(x, lambda g: g * ans * grad_gamma_logpdf_arg0(x, a)),
+       lambda ans, x, a: unbroadcast_f(a, lambda g: g * ans * grad_gamma_logpdf_arg1(x, a)))

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -42,6 +42,9 @@ else:
         return symmetrized_fun
 
     ### Stats ###
+    def test_gamma_pdf():    combo_check(stats.gamma.pdf,    [0,1])([R(4)**2 + 1.1], [R(4)**2 + 1.1])
+    def test_gamma_logpdf(): combo_check(stats.gamma.logpdf, [0,1])([R(4)**2 + 1.1], [R(4)**2 + 1.1])
+
     def test_norm_pdf():    combo_check(stats.norm.pdf,    [0,1,2])([R(4)], [R(4)], [R(4)**2 + 1.1])
     def test_norm_cdf():    combo_check(stats.norm.cdf,    [0,1,2])([R(4)], [R(4)], [R(4)**2 + 1.1])
     def test_norm_logpdf(): combo_check(stats.norm.logpdf, [0,1,2])([R(4)], [R(4)], [R(4)**2 + 1.1])

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -42,6 +42,7 @@ else:
         return symmetrized_fun
 
     ### Stats ###
+    def test_gamma_cdf():    combo_check(stats.gamma.cdf,    [0])  ([R(4)**2 + 1.1], [R(4)**2 + 1.1])
     def test_gamma_pdf():    combo_check(stats.gamma.pdf,    [0,1])([R(4)**2 + 1.1], [R(4)**2 + 1.1])
     def test_gamma_logpdf(): combo_check(stats.gamma.logpdf, [0,1])([R(4)**2 + 1.1], [R(4)**2 + 1.1])
 


### PR DESCRIPTION
This PR implements VJPs for the gamma PDF w.r.t. its argument and shape parameter (`x` and `a` in SciPy, respectively).