### PR TITLE
Simplify grad_and_aux

### DIFF
--- a/autograd/differential_operators.py
+++ b/autograd/differential_operators.py
@@ -130,14 +130,12 @@ def value_and_grad(fun, x):
     vjp, ans = _make_vjp(fun, x)
     return ans, vjp(vspace(ans).ones())
 
-def grad_and_aux(fun, argnum=0):
+@unary_to_nary
+def grad_and_aux(fun, x):
     """Builds a function that returns the gradient of the first output and the
     (unmodified) second output of a function that returns two outputs."""
-    diffable_fun = lambda *args, **kwargs: atuple(fun(*args, **kwargs))
-    def grad_and_aux_fun(*args, **kwargs):
-        vjp, (_, aux) = make_vjp(diffable_fun, argnum)(*args, **kwargs)
-        return vjp((1., vspace(aux).zeros())), aux
-    return grad_and_aux_fun
+    vjp, (ans, aux) = _make_vjp(lambda x: atuple(fun(x)), x)
+    return vjp((vspace(ans).ones(), vspace(aux).zeros())), aux
 
 def multigrad_dict(fun):
     "Takes gradients wrt all arguments simultaneously,"

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -8,7 +8,8 @@ from autograd.test_util import check_grads, check_equivalent # , nd
 from autograd.tracer import primitive, isbox
 from autograd import (grad, elementwise_grad, jacobian, value_and_grad,
                       hessian_tensor_product, hessian, make_hvp,
-                      tensor_jacobian_product, checkpoint, make_jvp, make_ggnvp)
+                      tensor_jacobian_product, checkpoint, make_jvp,
+                      make_ggnvp, grad_and_aux)
 
 npr.seed(1)
 
@@ -318,6 +319,18 @@ def test_make_ggnvp_nondefault_g():
 
     fun2 = lambda x: np.tanh(np.dot(A, x))
     check_equivalent(make_ggnvp(fun2, g)(x)(v), _make_explicit_ggnvp(fun2, g)(x)(v))
+
+def test_grad_and_aux():
+    A = npr.randn(5, 4)
+    x = npr.randn(4)
+
+    f = lambda x: (np.sum(np.dot(A, x)), x**2)
+    g = lambda x: np.sum(np.dot(A, x))
+
+    assert len(grad_and_aux(f)(x)) == 2
+
+    check_equivalent(grad_and_aux(f)(x)[0], grad(g)(x))
+    check_equivalent(grad_and_aux(f)(x)[1], x**2)
 
 ## No longer support this behavior
 # def test_make_ggnvp_broadcasting():


### PR DESCRIPTION
Figured this trick out whilst writing the code for https://github.com/HIPS/autograd/issues/339.

**TODO:**
- [x] Tests for this operator
- [x] Use `unary_to_nary` decorator