### PR TITLE
Correct exact/numeric vjv variable naming in check_vjp

### DIFF
--- a/autograd/test_util.py
+++ b/autograd/test_util.py
@@ -34,7 +34,7 @@ def check_vjp(f, x):
     assert scalar_close(vjv_numeric, vjv_exact), \
         ("Derivative (VJP) check of {} failed with arg {}:\n"
          "analytic: {}\nnumeric:  {}".format(
-            get_name(f), x, vjv_numeric, vjv_exact))
+            get_name(f), x, vjv_exact, vjv_numeric))
 
 def check_jvp(f, x):
     jvp = make_jvp(f, x)

--- a/autograd/test_util.py
+++ b/autograd/test_util.py
@@ -29,8 +29,8 @@ def check_vjp(f, x):
 
     vjp_y = x_vs.covector(vjp(y_vs.covector(y_v)))
     assert vspace(vjp_y) == x_vs
-    vjv_numeric = x_vs.inner_prod(x_v, vjp_y)
-    vjv_exact   = y_vs.inner_prod(y_v, jvp(x_v))
+    vjv_exact   = x_vs.inner_prod(x_v, vjp_y)
+    vjv_numeric = y_vs.inner_prod(y_v, jvp(x_v))
     assert scalar_close(vjv_numeric, vjv_exact), \
         ("Derivative (VJP) check of {} failed with arg {}:\n"
          "analytic: {}\nnumeric:  {}".format(


### PR DESCRIPTION
Have now realised the output order was actually correct because the variables were incorrectly swapped round twice, meaning they ended up back in the right place.