### PR TITLE
Raise NotImplementedError on negative rollaxis args

### DIFF
--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -121,8 +121,6 @@ defvjp(anp.clip,    lambda ans, x, a_min, a_max : lambda g: g * anp.logical_and(
 defvjp(anp.swapaxes, lambda ans, x, axis1, axis2: lambda g: anp.swapaxes(g, axis2, axis1))
 defvjp(anp.moveaxis, lambda ans, a, source, destination: lambda g:
                     anp.moveaxis(g, destination, source))
-defvjp(anp.rollaxis, lambda ans, a, axis, start=0: lambda g: anp.rollaxis(g, start - 1, axis) if start > axis
-                                                 else anp.rollaxis(g, start, axis + 1))
 defvjp(anp.real_if_close, lambda ans, x : lambda g: match_complex(x, g))
 defvjp(anp.real,   lambda ans, x   : lambda g: match_complex(x, g))
 defvjp(anp.imag,   lambda ans, x   : lambda g: match_complex(x, -1j * g))
@@ -144,6 +142,15 @@ defvjp(anp._astype,
        lambda g: anp._astype(g, A.dtype))
 
 # ----- Trickier grads -----
+def grad_rollaxis(ans, a, axis, start=0):
+    if axis < 0:
+        raise NotImplementedError("Gradient of rollaxis not implemented for axis < 0. "
+            "Please use moveaxis instead.")
+    elif start < 0:
+        raise NotImplementedError("Gradient of rollaxis not implemented for start < 0. "
+            "Please use moveaxis instead.")
+    return lambda g: anp.rollaxis(g, start - 1, axis) if start > axis else anp.rollaxis(g, start, axis + 1)
+defvjp(anp.rollaxis, grad_rollaxis)
 
 def grad_diff(ans, a, n=1, axis=-1):
     nd = anp.ndim(a)

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -200,7 +200,7 @@ def test_tril_3d():  combo_check(np.tril, [0])([R(5, 5, 4)], k=[-1, 0, 1])
 def test_triu_3d():  combo_check(np.triu, [0])([R(5, 5, 4)], k=[-1, 0, 1])
 
 def test_swapaxes(): combo_check(np.swapaxes, [0])([R(3, 4, 5)], axis1=[0, 1, 2], axis2=[0, 1, 2])
-def test_rollaxis(): combo_check(np.rollaxis, [0])([R(2, 3, 4)], axis =[0, 1, 2], start=[0, 1, 2, 3])
+def test_rollaxis(): combo_check(np.rollaxis, [0])([R(2, 3, 4)], axis =[0, 1, 2], start=[0, 1, 2])
 def test_cross():    combo_check(np.cross, [0, 1])([R(3, 3)], [R(3, 3)],
                                  axisa=[-1, 0, 1], axisb=[-1, 0, 1], axisc=[-1, 0, 1], axis=[None, -1, 0, 1])
 


### PR DESCRIPTION
This resolves https://github.com/HIPS/autograd/issues/350. I could have implemented the grad of rollaxis for negative args, however was put off by its nastiness (the `start` arg doesn't have the usual axis bounds - it can be equal to ndim which is quite weird). Indeed in the [new Numpy (1.14) doc for rollaxis](https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.rollaxis.html), it says

> This function continues to be supported for backward compatibility, but you should prefer `moveaxis`. The `moveaxis` function was added in NumPy 1.11.

So I hope you're ok with this fix.