### PR TITLE
Clarify in the doc string that elementwise_grad is only applicable to diagonal Jacobians

### DIFF
--- a/autograd/differential_operators.py
+++ b/autograd/differential_operators.py
@@ -30,6 +30,11 @@ def grad(fun, x):
 
 @unary_to_nary
 def elementwise_grad(fun, x):
+    """
+    Like `jacobian`, but produces a function which computes just the diagonal
+    of the Jacobian, and does the computation in one pass rather than in a loop.
+    Note: this is only valid if the Jacobian is diagonal, i.e. if all non-diagonal
+    elements are zero."""
     vjp, ans = _make_vjp(fun, x)
     if vspace(ans).iscomplex:
         raise TypeError("Elementwise_grad only applies to real-output functions.")


### PR DESCRIPTION
I think it's a limitation that is important to point out. Trying to use elementwise_grad for non-diagonal Jacobians will silently return incorrect values. 

I've copied and modified the doc from some older version of elementwise_grad. The doc could be extended further if there are any other features/limitations to be pointed out for the current version.