### PR TITLE
Return zero gradient for zero norm function.

### DIFF
--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -152,6 +152,26 @@ def test_norm_nuclear_axis():
     mat = npr.randn(D, D-1, D-2)
     check_grads(fun)(mat)
 
+def test_vector_zero_norm():
+    def helper(size, ord):
+        def fun(x): return np.linalg.norm(x, ord=ord)
+        vec = np.zeros(size)
+        check_grads(fun, order=1)(vec)
+    for ord in [1.1, 2, 3]:
+        for size in [1, 2]:
+            yield helper, size, ord
+
+def test_vector_mix_zero_norm_axis():
+    def helper(axis, ord):
+        def fun(x): return np.linalg.norm(x, ord=ord, axis=axis)
+        size = (2,2)
+        vecs = np.zeros(size)
+        vecs[0,0] = npr.randn(1)
+        check_grads(fun, order=1)(vecs)
+    for axis in [0, 1]:
+        for ord in [1.1, 2]:
+            yield helper, axis, ord
+
 def test_eigvalh_lower():
     def fun(x):
         w, v = np.linalg.eigh(x)


### PR DESCRIPTION
Fix issues https://github.com/HIPS/autograd/issues/370

Now the gradient at zero (origin) point of np.linalg.norm() is the same as np.abs, which is zero, one of its subgradient.
For second order gradients, mathematically they should be +infinity, but
here when ord>=2 it returns 0 (same as np.abs()), when 1<ord<2, it is
NaN with plenty of warnings, which should be enough to prevent user from
doing that.

Also note that when x is complex number, the gradient of the norm seems wrong according to your [document](https://github.com/HIPS/autograd/blob/master/docs/tutorial.md#complex-numbers), there should be a conj(x) in the expression, see also the comments in the committed code.