### PR TITLE
Added derivative for numpy.linalg.pinv() with a test (that passes).

### DIFF
--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -27,6 +27,16 @@ def grad_inv(ans, x):
     return lambda g: -dot(dot(T(ans), g), T(ans))
 defvjp(inv, grad_inv)
 
+def grad_pinv(ans, x):
+    dot = anp.dot if ans.ndim == 2 else partial(anp.einsum, '...ij,...jk->...ik')
+    # https://mathoverflow.net/questions/25778/analytical-formula-for-numerical-derivative-of-the-matrix-pseudo-inverse
+    return lambda g: T(
+        -dot(dot(ans, T(g)), ans)
+        + dot(dot(dot( ans, T(ans) ), g ), anp.eye(x.shape[0]) - dot(x,ans))
+        + dot(dot(dot( anp.eye(ans.shape[0]) - dot(ans,x), g ), T(ans) ), ans )
+        )
+defvjp(pinv, grad_pinv)
+
 def grad_solve(argnum, ans, a, b):
     updim = lambda x: x if x.ndim == a.ndim else x[...,None]
     dot = anp.dot if a.ndim == 2 else partial(anp.einsum, '...ij,...jk->...ik')

--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -16,6 +16,8 @@ wrap_namespace(npla.__dict__, globals())
 # transpose by swapping last two dimensions
 def T(x): return anp.swapaxes(x, -1, -2)
 
+_dot = partial(anp.einsum, '...ij,...jk->...ik')
+
 # add two dimensions to the end of x
 def add2d(x): return anp.reshape(x, anp.shape(x) + (1, 1))
 
@@ -23,25 +25,22 @@ defvjp(det, lambda ans, x: lambda g: add2d(g) * add2d(ans) * T(inv(x)))
 defvjp(slogdet, lambda ans, x: lambda g: add2d(g[1]) * T(inv(x)))
 
 def grad_inv(ans, x):
-    dot = anp.dot if ans.ndim == 2 else partial(anp.einsum, '...ij,...jk->...ik')
-    return lambda g: -dot(dot(T(ans), g), T(ans))
+    return lambda g: -_dot(_dot(T(ans), g), T(ans))
 defvjp(inv, grad_inv)
 
 def grad_pinv(ans, x):
-    dot = anp.dot if ans.ndim == 2 else partial(anp.einsum, '...ij,...jk->...ik')
     # https://mathoverflow.net/questions/25778/analytical-formula-for-numerical-derivative-of-the-matrix-pseudo-inverse
     return lambda g: T(
-        -dot(dot(ans, T(g)), ans)
-        + dot(dot(dot( ans, T(ans) ), g ), anp.eye(x.shape[0]) - dot(x,ans))
-        + dot(dot(dot( anp.eye(ans.shape[0]) - dot(ans,x), g ), T(ans) ), ans )
+        -_dot(_dot(ans, T(g)), ans)
+        + _dot(_dot(_dot(ans, T(ans)), g), anp.eye(x.shape[-2]) - _dot(x,ans))
+        + _dot(_dot(_dot(anp.eye(ans.shape[-2]) - _dot(ans,x), g), T(ans)), ans)
         )
 defvjp(pinv, grad_pinv)
 
 def grad_solve(argnum, ans, a, b):
     updim = lambda x: x if x.ndim == a.ndim else x[...,None]
-    dot = anp.dot if a.ndim == 2 else partial(anp.einsum, '...ij,...jk->...ik')
     if argnum == 0:
-        return lambda g: -dot(updim(solve(T(a), g)), T(updim(ans)))
+        return lambda g: -_dot(updim(solve(T(a), g)), T(updim(ans)))
     else:
         return lambda g: solve(T(a), g)
 defvjp(solve, partial(grad_solve, 0), partial(grad_solve, 1))
@@ -89,10 +88,9 @@ def grad_norm(ans, x, ord=None, axis=None):
         if ord is None or ord == 2 or ord is 'fro':
             return expand(g / ans) * x
         elif ord == 'nuc':
-            dot = anp.dot if x.ndim == 2 else partial(anp.einsum, '...ij,...jk->...ik')
             x_rolled = roll(x)
             u, s, vt = svd(x_rolled, full_matrices=False)
-            uvt_rolled = dot(u, vt)
+            uvt_rolled = _dot(u, vt)
             # Roll the matrix axes back to their correct positions
             uvt = unroll(uvt_rolled)
             g = expand(g)
@@ -107,13 +105,12 @@ def grad_eigh(ans, x, UPLO='L'):
     """Gradient for eigenvalues and vectors of a symmetric matrix."""
     N = x.shape[-1]
     w, v = ans              # Eigenvalues, eigenvectors.
-    dot = anp.dot if x.ndim == 2 else partial(anp.einsum, '...ij,...jk->...ik')
     def vjp(g):
         wg, vg = g          # Gradient w.r.t. eigenvalues, eigenvectors.
         w_repeated = anp.repeat(w[..., anp.newaxis], N, axis=-1)
         off_diag = anp.ones((N, N)) - anp.eye(N)
         F = off_diag / (T(w_repeated) - w_repeated + anp.eye(N))
-        return dot(v * wg[..., anp.newaxis, :] + dot(v, F * dot(T(v), vg)), T(v))
+        return _dot(v * wg[..., anp.newaxis, :] + _dot(v, F * _dot(T(v), vg)), T(v))
     return vjp
 defvjp(eigh, grad_eigh)
 
@@ -137,7 +134,6 @@ defvjp(cholesky, grad_cholesky)
 def grad_svd(usv_, a, full_matrices=True, compute_uv=True):
     def vjp(g):
         usv = usv_
-        dot = anp.dot if a.ndim == 2 else partial(anp.einsum, '...ij,...jk->...ik')
 
         if not compute_uv:
             s = usv
@@ -147,7 +143,7 @@ def grad_svd(usv_, a, full_matrices=True, compute_uv=True):
             u = usv[0]
             v = T(usv[2])
 
-            return dot(u * g[..., anp.newaxis, :], T(v))
+            return _dot(u * g[..., anp.newaxis, :], T(v))
 
         elif full_matrices:
             raise NotImplementedError(
@@ -171,19 +167,19 @@ def grad_svd(usv_, a, full_matrices=True, compute_uv=True):
                 gs = g[1]
                 gv = T(g[2])
 
-                utgu = dot(T(u), gu)
-                vtgv = dot(T(v), gv)
+                utgu = _dot(T(u), gu)
+                vtgv = _dot(T(v), gv)
 
                 i_minus_vvt = (anp.reshape(anp.eye(n), anp.concatenate((anp.ones(a.ndim - 2, dtype=int), (n, n)))) -
-                                dot(v, T(v)))
+                                _dot(v, T(v)))
 
                 t1 = (f * (utgu - T(utgu))) * s[..., anp.newaxis, :]
                 t1 = t1 + i * gs[..., :, anp.newaxis]
                 t1 = t1 + s[..., :, anp.newaxis] * (f * (vtgv - T(vtgv)))
 
-                t1 = dot(dot(u, t1), T(v))
+                t1 = _dot(_dot(u, t1), T(v))
 
-                t1 = t1 + dot(dot(u / s[..., anp.newaxis, :], T(gv)), i_minus_vvt)
+                t1 = t1 + _dot(_dot(u / s[..., anp.newaxis, :], T(gv)), i_minus_vvt)
 
                 return t1
 
@@ -192,14 +188,14 @@ def grad_svd(usv_, a, full_matrices=True, compute_uv=True):
                 gs = g[1]
                 gv = T(g[2])
 
-                utgu = dot(T(u), gu)
-                vtgv = dot(T(v), gv)
+                utgu = _dot(T(u), gu)
+                vtgv = _dot(T(v), gv)
 
                 t1 = (f * (utgu - T(utgu))) * s[..., anp.newaxis, :]
                 t1 = t1 + i * gs[..., :, anp.newaxis]
                 t1 = t1 + s[..., :, anp.newaxis] * (f * (vtgv - T(vtgv)))
 
-                t1 = dot(dot(u, t1), T(v))
+                t1 = _dot(_dot(u, t1), T(v))
 
                 return t1
 
@@ -208,19 +204,19 @@ def grad_svd(usv_, a, full_matrices=True, compute_uv=True):
                 gs = g[1]
                 gv = T(g[2])
 
-                utgu = dot(T(u), gu)
-                vtgv = dot(T(v), gv)
+                utgu = _dot(T(u), gu)
+                vtgv = _dot(T(v), gv)
 
                 i_minus_uut = (anp.reshape(anp.eye(m), anp.concatenate((anp.ones(a.ndim - 2, dtype=int), (m, m)))) -
-                                dot(u, T(u)))
+                                _dot(u, T(u)))
 
                 t1 = (f * (utgu - T(utgu))) * s[..., anp.newaxis, :]
                 t1 = t1 + i * gs[..., :, anp.newaxis]
                 t1 = t1 + s[..., :, anp.newaxis] * (f * (vtgv - T(vtgv)))
 
-                t1 = dot(dot(u, t1), T(v))
+                t1 = _dot(_dot(u, t1), T(v))
 
-                t1 = t1 + dot(i_minus_uut, dot(gu, T(v) / s[..., :, anp.newaxis]))
+                t1 = t1 + _dot(i_minus_uut, _dot(gu, T(v) / s[..., :, anp.newaxis]))
 
                 return t1
     return vjp

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -39,16 +39,16 @@ def test_pinv():
     def fun(x): return np.linalg.pinv(x)
     N = 8
     ## Non-square matrices:
-    for M in range( N//2, N + N//2 + 1 ):
+    for M in range(N // 2, N + N // 2 + 1):
         mat = npr.randn(N, M)
         check_grads(fun)(mat)
-    
-    ## Square matrices with varying ranks:
-    ## This doesn't work because the numerical derivative explodes.
-    #for M in range( N//2, N + N//2 + 1 ):
-    #    mat = npr.randn(N, M)
-    #    mat = np.dot(mat, mat.T)
-    #    check_grads(fun)(mat)
+
+    ## Square, low (fixed) rank matrices
+    def fun_low_rank(x): return np.linalg.pinv(np.dot(np.transpose(x), x))
+
+    for M in range(N // 2, N + N // 2 + 1):
+        mat = npr.randn(N, M)
+        check_grads(fun_low_rank)(mat)
 
 def test_inv_3d():
     fun = lambda x: np.linalg.inv(x)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -35,6 +35,21 @@ def test_inv():
     mat = np.dot(mat, mat) + 1.0 * np.eye(D)
     check_grads(fun)(mat)
 
+def test_pinv():
+    def fun(x): return np.linalg.pinv(x)
+    N = 8
+    ## Non-square matrices:
+    for M in range( N//2, N + N//2 + 1 ):
+        mat = npr.randn(N, M)
+        check_grads(fun)(mat)
+    
+    ## Square matrices with varying ranks:
+    ## This doesn't work because the numerical derivative explodes.
+    #for M in range( N//2, N + N//2 + 1 ):
+    #    mat = npr.randn(N, M)
+    #    mat = np.dot(mat, mat.T)
+    #    check_grads(fun)(mat)
+
 def test_inv_3d():
     fun = lambda x: np.linalg.inv(x)
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -37,17 +37,25 @@ def test_inv():
 
 def test_pinv():
     def fun(x): return np.linalg.pinv(x)
-    N = 8
+    N = 5
+    D = 2
     ## Non-square matrices:
     for M in range(N // 2, N + N // 2 + 1):
         mat = npr.randn(N, M)
         check_grads(fun)(mat)
+        # Stacked
+        mat = npr.randn(D, N, M)
+        check_grads(fun)(mat)
+
 
     ## Square, low (fixed) rank matrices
-    def fun_low_rank(x): return np.linalg.pinv(np.dot(np.transpose(x), x))
+    def fun_low_rank(x): return np.linalg.pinv(np.linalg._dot(np.linalg.T(x), x))
 
     for M in range(N // 2, N + N // 2 + 1):
         mat = npr.randn(N, M)
+        check_grads(fun_low_rank)(mat)
+        # Stacked
+        mat = npr.randn(D, N, M)
         check_grads(fun_low_rank)(mat)
 
 def test_inv_3d():


### PR DESCRIPTION
This is a replacement for pull request https://github.com/HIPS/autograd/pull/383.

It adds a test that passes. Good thing the other pull request (without a test) wasn't accepted. It was wrong for non-square, symmetric matrices.