### PR TITLE
Fix vjp for multivariate normal covariance

### DIFF
--- a/autograd/scipy/stats/multivariate_normal.py
+++ b/autograd/scipy/stats/multivariate_normal.py
@@ -42,7 +42,7 @@ defvjp(logpdf,
        lambda ans, x, mean, cov, allow_singular=False:
        unbroadcast_f(mean, lambda g:  np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T),
        lambda ans, x, mean, cov, allow_singular=False:
-       unbroadcast_f(cov, lambda g: -np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)))
+       unbroadcast_f(cov, lambda g: np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)))
 
 # Same as log pdf, but multiplied by the pdf (ans).
 defvjp(pdf,
@@ -51,7 +51,7 @@ defvjp(pdf,
        lambda ans, x, mean, cov, allow_singular=False:
        unbroadcast_f(mean, lambda g:  np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T),
        lambda ans, x, mean, cov, allow_singular=False:
-       unbroadcast_f(cov, lambda g: -np.reshape(ans * g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)))
+       unbroadcast_f(cov, lambda g: np.reshape(ans * g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)))
 
 defvjp(entropy, None,
        lambda ans, mean, cov:

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -84,9 +84,9 @@ else:
     def test_t_logcdf_broadcast(): combo_check(stats.t.logcdf, [0,2])(    [R(4,3)], [R(1,3)**2 + 2.1], [R(4,3)], [R(4,1)**2 + 2.1])
 
     def make_psd(mat): return np.dot(mat.T, mat) + np.eye(mat.shape[0])
-    def test_mvn_pdf():    combo_check(symmetrize_matrix_arg(mvn.pdf, 2), [0, 1, 2], [R(4)], [R(4)], [make_psd(R(4, 4))], allow_singular=[False])
-    def test_mvn_logpdf(): combo_check(symmetrize_matrix_arg(mvn.logpdf, 2), [0, 1, 2], [R(4)], [R(4)], [make_psd(R(4, 4))], allow_singular=[False])
-    def test_mvn_entropy():combo_check(mvn.entropy,[0, 1],            [R(4)], [make_psd(R(4, 4))])
+    def test_mvn_pdf():    combo_check(symmetrize_matrix_arg(mvn.pdf, 2), [0, 1, 2])([R(4)], [R(4)], [make_psd(R(4, 4))], allow_singular=[False])
+    def test_mvn_logpdf(): combo_check(symmetrize_matrix_arg(mvn.logpdf, 2), [0, 1, 2])([R(4)], [R(4)], [make_psd(R(4, 4))], allow_singular=[False])
+    def test_mvn_entropy():combo_check(mvn.entropy,[0, 1])([R(4)], [make_psd(R(4, 4))])
 
     C = np.zeros((4, 4))
     C[0, 0] = C[1, 1] = 1
@@ -94,8 +94,8 @@ else:
     def test_mvn_pdf_sing_cov(): combo_check(mvn.pdf, [0, 1])([np.concatenate((R(2), np.zeros(2)))], [np.concatenate((R(2), np.zeros(2)))], [C], [True])
     def test_mvn_logpdf_sing_cov(): combo_check(mvn.logpdf, [0, 1])([np.concatenate((R(2), np.zeros(2)))], [np.concatenate((R(2), np.zeros(2)))], [C], [True])
 
-    def test_mvn_pdf_broadcast():    combo_check(symmetrize_matrix_arg(mvn.pdf, 2), [0, 1, 2], [R(5, 4)], [R(4)], [make_psd(R(4, 4))])
-    def test_mvn_logpdf_broadcast(): combo_check(symmetrize_matrix_arg(mvn.logpdf, 2), [0, 1, 2], [R(5, 4)], [R(4)], [make_psd(R(4, 4))])
+    def test_mvn_pdf_broadcast():    combo_check(symmetrize_matrix_arg(mvn.pdf, 2), [0, 1, 2])([R(5, 4)], [R(4)], [make_psd(R(4, 4))])
+    def test_mvn_logpdf_broadcast(): combo_check(symmetrize_matrix_arg(mvn.logpdf, 2), [0, 1, 2])([R(5, 4)], [R(4)], [make_psd(R(4, 4))])
 
     alpha = npr.random(4)**2 + 1.2
     x = stats.dirichlet.rvs(alpha, size=1)[0,:]


### PR DESCRIPTION
This pull request adjusts the vjp for the multivariate normal covariance parameter, which was returning gradients with the wrong sign. It seems that a small typo in the unit test script had been preventing the tests for these vjps from running, which is probably why this wasn't picked up earlier. Resolves issue #401 .