### PR TITLE
linear combination of hessians

### DIFF
--- a/autograd/__init__.py
+++ b/autograd/__init__.py
@@ -3,6 +3,7 @@ from .differential_operators import (
     make_vjp, grad, multigrad_dict, elementwise_grad, value_and_grad,
     grad_and_aux, hessian_tensor_product, hessian_vector_product, hessian,
     jacobian, tensor_jacobian_product, vector_jacobian_product, grad_named,
-    checkpoint, make_hvp, make_jvp, make_ggnvp, deriv, holomorphic_grad)
+    checkpoint, make_hvp, make_jvp, make_ggnvp, deriv, holomorphic_grad,
+    linear_combination_of_hessians)
 from .builtins import isinstance, type, tuple, list, dict
 from autograd.core import primitive_with_deprecation_warnings as primitive

--- a/autograd/differential_operators.py
+++ b/autograd/differential_operators.py
@@ -105,6 +105,30 @@ def tensor_jacobian_product(fun, argnum=0):
     return jacobian(vector_dot_fun, argnum)
 vector_jacobian_product = tensor_jacobian_product
 
+def linear_combination_of_hessians(fun, argnum=0, *args, **kwargs):
+  """
+  Returns a function that computes the linear combination of hessians.
+  The returned function as arguments (*args, vector, **kwargs),
+  where vector is used for the linear combination.
+  """
+  functionhessian = hessian(fun, argnum, *args, **kwargs)
+  #not using wrap_nary_f because we need to do the docstring on our own
+  def linear_combination_of_hessians(*funargs, **funkwargs):
+    return np.tensordot(functionhessian(*funargs[:-1], **funkwargs), funargs[-1], axes=(0, 0))
+
+  linear_combination_of_hessians.__name__ = functionhessian.__name__.replace(
+    "hessian", "linear_combination_of_hessians", 1
+  )
+
+  linear_combination_of_hessians.__doc__ = """
+    linear combination of hessians of function {fun.__name__} with respect to
+    argument number {argnum}.  Takes the same arguments as {fun.__name__} plus a vector
+    (given as a final, non-keyword argument) to dot with the hessians.
+  """.lstrip("\n").format(fun=fun, argnum=argnum)
+
+  return linear_combination_of_hessians
+
+
 @unary_to_nary
 def make_jvp_reversemode(fun, x):
     """Builds a function for evaluating the Jacobian-vector product at a

--- a/examples/minimize_nonlinear_constraint.py
+++ b/examples/minimize_nonlinear_constraint.py
@@ -1,0 +1,29 @@
+useconstraint = True
+
+import autograd
+import autograd.numpy as np
+from scipy import optimize
+
+def function(x): return x[0]**2 + x[1]**2
+functionjacobian = autograd.jacobian(function)
+functionhvp = autograd.hessian_vector_product(function)
+
+def constraint(x): return np.array([x[0]**2 - (x[1]-1)**2])
+constraintjacobian = autograd.jacobian(constraint)
+constraintlcoh = autograd.linear_combination_of_hessians(constraint)
+
+constraint = optimize.NonlinearConstraint(constraint, 2, np.inf, constraintjacobian, constraintlcoh)
+
+startpoint = [1, 2]
+
+bounds = optimize.Bounds([-np.inf, -np.inf], [np.inf, np.inf])
+
+print optimize.minimize(
+  function,
+  startpoint,
+  method='trust-constr',
+  jac=functionjacobian,
+  hessp=functionhvp,
+  constraints=[constraint] if useconstraint else [],
+  bounds=bounds,
+)


### PR DESCRIPTION
as expected by scipy.optimize.NonlinearConstraint, and an example of its use.

The example scripy may require scipy/scipy#9931.  It gave an error as I was testing it, and I found that fix to the error, but now it seems to work with or without that fix.  I'm not sure what's going on there.  However it's clearly orthogonal to the actual implementation of `linear_combination_of_hessians`.