### PR TITLE
Fix scipy deprecation warning

### DIFF
--- a/autograd/scipy/misc.py
+++ b/autograd/scipy/misc.py
@@ -1,28 +1,7 @@
 from __future__ import absolute_import
-import scipy.misc
-from autograd.extend import primitive, defvjp, defjvp
-import autograd.numpy as anp
-from autograd.numpy.numpy_vjps import repeat_to_match_shape
 
-logsumexp = primitive(scipy.special.logsumexp)
+import scipy.misc as osp_misc
+from ..scipy import special
 
-def make_grad_logsumexp(ans, x, axis=None, b=1.0, keepdims=False):
-    shape, dtype = anp.shape(x), anp.result_type(x)
-    def vjp(g):
-        g_repeated,   _ = repeat_to_match_shape(g,   shape, dtype, axis, keepdims)
-        ans_repeated, _ = repeat_to_match_shape(ans, shape, dtype, axis, keepdims)
-        return g_repeated * b * anp.exp(x - ans_repeated)
-    return vjp
-
-defvjp(logsumexp, make_grad_logsumexp)
-
-def fwd_grad_logsumexp(g, ans, x, axis=None, b=1.0, keepdims=False):
-    if not keepdims:
-        if isinstance(axis, int):
-            ans = anp.expand_dims(ans, axis)
-        elif isinstance(axis, tuple):
-            for ax in sorted(axis):
-                ans = anp.expand_dims(ans, ax)
-    return anp.sum(g * b * anp.exp(x - ans), axis=axis, keepdims=keepdims)
-
-defjvp(logsumexp, fwd_grad_logsumexp)
+if hasattr(osp_misc, 'logsumexp'):
+    logsumexp = special.logsumexp

--- a/autograd/scipy/misc.py
+++ b/autograd/scipy/misc.py
@@ -4,7 +4,7 @@ from autograd.extend import primitive, defvjp, defjvp
 import autograd.numpy as anp
 from autograd.numpy.numpy_vjps import repeat_to_match_shape
 
-logsumexp = primitive(scipy.misc.logsumexp)
+logsumexp = primitive(scipy.special.logsumexp)
 
 def make_grad_logsumexp(ans, x, axis=None, b=1.0, keepdims=False):
     shape, dtype = anp.shape(x), anp.result_type(x)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -189,7 +189,7 @@ This can happen if your code depends on external library calls or C code.
 It can sometimes even be a good idea to provide the gradient of a pure Python function for speed or numerical stability.
 
 For example, let's add the gradient of a numerically stable version of `log(sum(exp(x)))`.
-This function is included in `scipy.misc` and already supported, but let's make our own version.
+This function is included in `scipy.special` and already supported, but let's make our own version.
 
 Next, we define our function using standard Python, using `@primitive` as a decorator:
 

--- a/examples/define_gradient.py
+++ b/examples/define_gradient.py
@@ -17,7 +17,7 @@ from autograd.test_util import check_grads
 # how to execute, and you can do things like in-place operations on arrays.
 @primitive
 def logsumexp(x):
-    """Numerically stable log(sum(exp(x))), also defined in scipy.misc"""
+    """Numerically stable log(sum(exp(x))), also defined in scipy.special"""
     max_x = np.max(x)
     return max_x + np.log(np.sum(np.exp(x - max_x)))
 

--- a/examples/gmm.py
+++ b/examples/gmm.py
@@ -10,7 +10,7 @@ import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import grad, hessian_vector_product
 from scipy.optimize import minimize
-from autograd.scipy.misc import logsumexp
+from autograd.scipy.special import logsumexp
 import autograd.scipy.stats.multivariate_normal as mvn
 from autograd.misc.flatten import flatten_func
 from data import make_pinwheel

--- a/examples/hmm_em.py
+++ b/examples/hmm_em.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.scipy.misc import logsumexp
+from autograd.scipy.special import logsumexp
 from autograd import value_and_grad as vgrad
 from functools import partial
 from os.path import join, dirname

--- a/examples/lstm.py
+++ b/examples/lstm.py
@@ -9,7 +9,7 @@ from os.path import dirname, join
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import grad
-from autograd.scipy.misc import logsumexp
+from autograd.scipy.special import logsumexp
 
 from autograd.misc.optimizers import adam
 from rnn import string_to_one_hot, one_hot_to_string,\

--- a/examples/mixture_variational_inference.py
+++ b/examples/mixture_variational_inference.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import autograd.numpy as np
 import autograd.numpy.random as npr
 import autograd.scipy.stats.norm as norm
-from autograd.scipy.misc import logsumexp
+from autograd.scipy.special import logsumexp
 
 from autograd import grad
 from autograd.misc.optimizers import adam

--- a/examples/neural_net.py
+++ b/examples/neural_net.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division
 from __future__ import print_function
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.scipy.misc import logsumexp
+from autograd.scipy.special import logsumexp
 from autograd import grad
 from autograd.misc.flatten import flatten
 from autograd.misc.optimizers import adam

--- a/examples/rnn.py
+++ b/examples/rnn.py
@@ -8,7 +8,7 @@ from builtins import range
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import grad
-from autograd.scipy.misc import logsumexp
+from autograd.scipy.special import logsumexp
 from os.path import dirname, join
 from autograd.misc.optimizers import adam
 

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -11,7 +11,6 @@ except:
 else:
     import autograd.numpy as np
     import autograd.numpy.random as npr
-    import autograd.scipy.misc
     import autograd.scipy.signal
     import autograd.scipy.stats as stats
     import autograd.scipy.stats.multivariate_normal as mvn
@@ -115,14 +114,14 @@ else:
     def test_dirichlet_logpdf_alpha(): combo_check(stats.dirichlet.logpdf,      [1])([x], [alpha])
 
     ### Misc ###
-    def test_logsumexp1(): combo_check(autograd.scipy.misc.logsumexp, [0], modes=['fwd', 'rev'])([1.1, R(4), R(3,4)],                axis=[None, 0],    keepdims=[True, False])
-    def test_logsumexp2(): combo_check(autograd.scipy.misc.logsumexp, [0], modes=['fwd', 'rev'])([R(3,4), R(4,5,6), R(1,5)],         axis=[None, 0, 1], keepdims=[True, False])
-    def test_logsumexp3(): combo_check(autograd.scipy.misc.logsumexp, [0], modes=['fwd', 'rev'])([R(4)], b = [np.exp(R(4))],         axis=[None, 0],    keepdims=[True, False])
-    def test_logsumexp4(): combo_check(autograd.scipy.misc.logsumexp, [0], modes=['fwd', 'rev'])([R(3,4),], b = [np.exp(R(3,4))],    axis=[None, 0, 1], keepdims=[True, False])
-    def test_logsumexp5(): combo_check(autograd.scipy.misc.logsumexp, [0], modes=['fwd', 'rev'])([R(2,3,4)], b = [np.exp(R(2,3,4))], axis=[None, 0, 1], keepdims=[True, False])
+    def test_logsumexp1(): combo_check(special.logsumexp, [0], modes=['fwd', 'rev'])([1.1, R(4), R(3,4)],                axis=[None, 0],    keepdims=[True, False])
+    def test_logsumexp2(): combo_check(special.logsumexp, [0], modes=['fwd', 'rev'])([R(3,4), R(4,5,6), R(1,5)],         axis=[None, 0, 1], keepdims=[True, False])
+    def test_logsumexp3(): combo_check(special.logsumexp, [0], modes=['fwd', 'rev'])([R(4)], b = [np.exp(R(4))],         axis=[None, 0],    keepdims=[True, False])
+    def test_logsumexp4(): combo_check(special.logsumexp, [0], modes=['fwd', 'rev'])([R(3,4),], b = [np.exp(R(3,4))],    axis=[None, 0, 1], keepdims=[True, False])
+    def test_logsumexp5(): combo_check(special.logsumexp, [0], modes=['fwd', 'rev'])([R(2,3,4)], b = [np.exp(R(2,3,4))], axis=[None, 0, 1], keepdims=[True, False])
     def test_logsumexp6():
         x = npr.randn(1,5)
-        def f(a): return autograd.scipy.misc.logsumexp(a, axis=1, keepdims=True)
+        def f(a): return special.logsumexp(a, axis=1, keepdims=True)
         check_grads(f, modes=['fwd', 'rev'])(x)
         check_grads(lambda a: grad(f)(a), modes=['fwd', 'rev'])(x)
 


### PR DESCRIPTION
I am building a project using `autograd`, and using `autograd.scipy.misc.logsumexp` emits a warning. This is a tiny thing, since it is suppressed normally, unless you pass a flag, or are using `autograd` with `pytest`.

You can see the warning by starting python with `python -Wall`, and running

```python
from autograd.scipy.misc import logsumexp
logsumexp([1])

/home/projects/autograd/autograd/tracer.py:48: DeprecationWarning: `logsumexp` is deprecated!
Importing `logsumexp` from scipy.misc is deprecated in scipy 1.0.0. Use `scipy.special.logsumexp` instead.
  return f_raw(*args, **kwargs)
1.0
```

This is the smallest, easiest way to make the fix -- I am also happy to follow the scipy path (so `from autograd.scipy.misc import logsumexp` emits a warning, but `from autograd.scipy.special import logsumexp` does not).

Thanks for this very nice project!