### PR TITLE
Add VJP for numpy.gradient

### DIFF
--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -126,6 +126,7 @@ defjvp(anp.where,  None,
 # ----- Trickier grads -----
 defjvp(anp.kron,      'same', 'same')
 defjvp(anp.diff,      'same')
+defjvp(anp.gradient,  'same')
 defjvp(anp.repeat,    'same')
 defjvp(anp.tile,      'same')
 defjvp(anp.transpose, 'same')

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -163,9 +163,7 @@ def grad_diff(ans, a, n=1, axis=-1):
 
     def undiff(g):
         if g.shape[axis] > 0:
-            return anp.concatenate(
-                (-g[sl1], -anp.diff(g, axis=axis), g[sl2]), 
-                axis=axis)
+            return anp.concatenate((-g[sl1], -anp.diff(g, axis=axis), g[sl2]), axis=axis)
         shape = list(ans_shape)
         shape[axis] = 1
         return anp.zeros(shape)

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -176,6 +176,63 @@ def grad_diff(ans, a, n=1, axis=-1):
 
 defvjp(anp.diff, grad_diff)
 
+def grad_gradient(ans, x, axis=None):
+    if axis is None:
+        if ans.ndim == x.ndim:
+            # 1D case (no axis but same shape)
+            axis = [0]
+        else:
+            # gradient along all axes
+            axis = range(x.ndim)
+
+    elif type(axis) is int:
+        # not 1D but only along 1 axis
+        axis = [axis]
+
+    elif not onp.iterable(axis):
+        raise ValueError("`axis` must be None, int or iterable")
+
+    if len(axis) == 1:
+        # along one axis only, can be 1D or nD array
+        def vjp(g):
+            # Jacobian of np.gradient is mainly negative gradient
+            out = (-1.) * onp.gradient(g, axis=axis[0])
+
+            # shift gradient axis to the front
+            out_swap = out.swapaxes(0, axis[0])
+            g_swap = g.swapaxes(0, axis[0])
+
+            # border handling
+            out_swap[0] = -g_swap[0] - 0.5 * g_swap[1]
+            out_swap[1] =  g_swap[0] - 0.5 * g_swap[2]
+            out_swap[-2] = 0.5 * g_swap[-3] - g_swap[-1]
+            out_swap[-1] = 0.5 * g_swap[-2] + g_swap[-1]
+
+            return out
+
+    else:
+        # nd case
+        def vjp(g):
+            out = onp.zeros_like(g)
+            for i, k in enumerate(axis):
+                # Jacobian of np.gradient is mainly negative gradient
+                out[i] = (-1.) * onp.array(onp.gradient(g[i], axis=k))
+
+                # border handling 
+                out_swap = out.swapaxes(1, 1+k)
+                g_swap = g.swapaxes(1, 1+k)
+
+                out_swap[i, 0] = -g_swap[i, 0] - 0.5 * g_swap[i, 1]
+                out_swap[i, 1] =  g_swap[i, 0] - 0.5 * g_swap[i, 2]
+                out_swap[i, -2] = 0.5 * g_swap[i, -3] - g_swap[i, -1]
+                out_swap[i, -1] = 0.5 * g_swap[i, -2] + g_swap[i, -1]
+
+            return onp.sum(out, axis=0)
+
+    return vjp
+
+defvjp(anp.gradient, grad_gradient)
+
 def grad_repeat(ans, x, repeats, axis=None):
     shape = anp.shape(x)
     def vjp(g):

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -189,8 +189,14 @@ def grad_gradient(ans, x, axis=None):
         # not 1D but only along 1 axis
         axis = [axis]
 
-    elif not onp.iterable(axis):
-        raise ValueError("`axis` must be None, int or iterable")
+    else:
+        # axis should be already iterable 
+        axis = list(axis)
+
+    # makes negative indices in axis positive 
+    # (needed for axis swap later)
+    for i, a in enumerate(axis):
+        if a < 0: axis[i] = x.ndim + a
 
     if len(axis) == 1:
         # along one axis only, can be 1D or nD array

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -176,7 +176,12 @@ def grad_diff(ans, a, n=1, axis=-1):
 
 defvjp(anp.diff, grad_diff)
 
-def grad_gradient(ans, x, axis=None):
+def grad_gradient(ans, x, *vargs, **kwargs):
+    axis = kwargs.pop('axis', None)
+    if vargs or kwargs:
+        raise NotImplementedError(
+            "The only optional argument currently supported for np.gradient "
+            "is axis.")
     if axis is None:
         axis = range(x.ndim)
     elif type(axis) is int:
@@ -189,11 +194,11 @@ def grad_gradient(ans, x, axis=None):
     nd = x.ndim
 
     def vjp(g):
-        if g.ndim == nd:
+        if anp.ndim(g) == nd:
             # add axis if gradient was along one axis only
             g = g[anp.newaxis]
 
-        # accumulate gradient 
+        # accumulate gradient
         out = anp.zeros(x_shape, dtype=x_dtype)
 
         for i, a in enumerate(axis):

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -184,9 +184,6 @@ def grad_gradient(ans, x, axis=None):
     else:
         axis = list(axis)
 
-    # make all indices positive
-    axis = [(x.ndim + a) % x.ndim for a in axis]
-
     x_dtype = x.dtype
     x_shape = x.shape
     nd = x.ndim

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -113,10 +113,6 @@ def append(arr, values, axis=None):
         axis = ndim(arr) - 1
     return concatenate((arr, values), axis=axis)
 
-@primitive
-def gradient(arr, axis=None):
-    return _np.array(_np.gradient(arr, axis=axis), dtype=arr.dtype)
-
 # ----- Enable functions called using [] ----
 
 class r_class():

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -113,6 +113,10 @@ def append(arr, values, axis=None):
         axis = ndim(arr) - 1
     return concatenate((arr, values), axis=axis)
 
+@primitive
+def gradient(arr, axis=None):
+    return _np.array(_np.gradient(arr, axis=axis), dtype=arr.dtype)
+
 # ----- Enable functions called using [] ----
 
 class r_class():

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -696,3 +696,15 @@ def test_astype():
     x = np.arange(3, dtype='float32')
     def f(x): return np.sum(np.sin(x.astype('float64')))
     assert grad(f)(x).dtype == np.dtype('float32')
+
+def test_gradient():
+    check_grads(np.gradient, 0, modes=['rev'], order=1)(npr.randn(10))
+    check_grads(np.gradient, 0, modes=['rev'], order=1)(npr.randn(10, 10))
+    check_grads(np.gradient, 0, modes=['rev'], order=1)(npr.randn(10, 10, 10))
+
+    for a in [None, 0, 1, -1, (0, 1), (0, -1)]:
+        check_grads(
+            lambda x: np.gradient(x, axis=a), 
+            0, modes=['rev'], order=1)(npr.randn(10, 10, 10))
+
+

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -705,6 +705,6 @@ def test_gradient():
     for a in [None, 0, 1, -1, (0, 1), (0, -1)]:
         check_grads(
             lambda x: np.gradient(x, axis=a), 
-            0, modes=['rev'], order=1)(npr.randn(10, 10, 10))
+            0, order=1)(npr.randn(10, 10, 10))
 
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -698,13 +698,11 @@ def test_astype():
     assert grad(f)(x).dtype == np.dtype('float32')
 
 def test_gradient():
-    check_grads(np.gradient, 0, modes=['rev'], order=1)(npr.randn(10))
-    check_grads(np.gradient, 0, modes=['rev'], order=1)(npr.randn(10, 10))
-    check_grads(np.gradient, 0, modes=['rev'], order=1)(npr.randn(10, 10, 10))
+    check_grads(np.gradient, 0, order=1)(npr.randn(10))
+    check_grads(np.gradient, 0, order=1)(npr.randn(10, 10))
+    check_grads(np.gradient, 0, order=1)(npr.randn(10, 10, 10))
 
     for a in [None, 0, 1, -1, (0, 1), (0, -1)]:
-        check_grads(
-            lambda x: np.gradient(x, axis=a), 
-            0, order=1)(npr.randn(10, 10, 10))
+        check_grads(np.gradient, 0, order=1)(npr.randn(10, 10, 10), axis=a)
 
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -704,5 +704,3 @@ def test_gradient():
 
     for a in [None, 0, 1, -1, (0, 1), (0, -1)]:
         check_grads(np.gradient, 0, order=1)(npr.randn(10, 10, 10), axis=a)
-
-

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -698,9 +698,9 @@ def test_astype():
     assert grad(f)(x).dtype == np.dtype('float32')
 
 def test_gradient():
-    check_grads(np.gradient, 0, order=1)(npr.randn(10))
-    check_grads(np.gradient, 0, order=1)(npr.randn(10, 10))
-    check_grads(np.gradient, 0, order=1)(npr.randn(10, 10, 10))
+    check_grads(np.gradient, 0)(npr.randn(10))
+    check_grads(np.gradient, 0)(npr.randn(10, 10))
+    check_grads(np.gradient, 0)(npr.randn(10, 10, 10))
 
     for a in [None, 0, 1, -1, (0, 1), (0, -1)]:
-        check_grads(np.gradient, 0, order=1)(npr.randn(10, 10, 10), axis=a)
+        check_grads(np.gradient, 0)(npr.randn(10, 10, 10), axis=a)

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -95,7 +95,7 @@ def test_diff():
     combo_check(np.diff, [0])([R(1,1), R(3,1)], axis=[1])
 
 def test_gradient():
-    combo_check(np.gradient, [0])([R(5,5), R(5,5,5)], axis=[0,1,-1])
+    combo_check(np.gradient, [0])([R(5,5), R(5,5,5)], axis=[None,0,1,-1])
     combo_check(np.gradient, [0])([R(5,5,5)], axis=[(0, 1), (0, -1)])
 
 def test_tile():

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -96,6 +96,7 @@ def test_diff():
 
 def test_gradient():
     combo_check(np.gradient, [0], order=1)([R(5,5), R(5,5,5)], axis=[0,1,-1])
+    combo_check(np.gradient, [0], order=1)([R(5,5,5)], axis=[(0, 1), (0, -1)])
 
 def test_tile():
     combo_check(np.tile, [0])([R(2,1,3,1)], reps=[(1, 4, 1, 2)])

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -94,6 +94,9 @@ def test_diff():
     combo_check(np.diff, [0])([R(1), R(1,1)], axis=[0])
     combo_check(np.diff, [0])([R(1,1), R(3,1)], axis=[1])
 
+def test_gradient():
+    combo_check(np.gradient, [0], order=1)([R(5,5), R(5,5,5)], axis=[0,1,-1])
+
 def test_tile():
     combo_check(np.tile, [0])([R(2,1,3,1)], reps=[(1, 4, 1, 2)])
     combo_check(np.tile, [0])([R(1,2)], reps=[(1,2), (2,3), (3,2,1)])

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -95,8 +95,8 @@ def test_diff():
     combo_check(np.diff, [0])([R(1,1), R(3,1)], axis=[1])
 
 def test_gradient():
-    combo_check(np.gradient, [0], order=1)([R(5,5), R(5,5,5)], axis=[0,1,-1])
-    combo_check(np.gradient, [0], order=1)([R(5,5,5)], axis=[(0, 1), (0, -1)])
+    combo_check(np.gradient, [0])([R(5,5), R(5,5,5)], axis=[0,1,-1])
+    combo_check(np.gradient, [0])([R(5,5,5)], axis=[(0, 1), (0, -1)])
 
 def test_tile():
     combo_check(np.tile, [0])([R(2,1,3,1)], reps=[(1, 4, 1, 2)])


### PR DESCRIPTION
I've implemented a VJP for `numpy.gradient`. The function `numpy.gradient` itself is wrapped in `autograd.numpy` and only accepts the `axis` keyword. 

ATM only first order diff works due to the manual assignment in the VJP (see e.g. `numpy_vjps.py:212`). 