### PR TITLE
MAINT: fix numpy warnings, mainly by converting to tuple

### DIFF
--- a/autograd/numpy/fft.py
+++ b/autograd/numpy/fft.py
@@ -96,9 +96,9 @@ defvjp(ifftshift, lambda ans, x, axes=None : lambda g:
 def truncate_pad(x, shape):
     # truncate/pad x to have the appropriate shape
     slices = [slice(n) for n in shape]
-    pads = list(zip(anp.zeros(len(shape), dtype=int),
+    pads = tuple(zip(anp.zeros(len(shape), dtype=int),
                anp.maximum(0, anp.array(shape) - anp.array(x.shape))))
-    return anp.pad(x, pads, 'constant')[slices]
+    return anp.pad(x, pads, 'constant')[tuple(slices)]
 defvjp(truncate_pad, lambda ans, x, shape: lambda g:
        match_complex(x, truncate_pad(g, vspace(x).shape)))
 

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -163,7 +163,7 @@ def grad_diff(ans, a, n=1, axis=-1):
 
     def undiff(g):
         if g.shape[axis] > 0:
-            return anp.concatenate((-g[sl1], -anp.diff(g, axis=axis), g[sl2]), axis=axis)
+            return anp.concatenate((-g[tuple(sl1)], -anp.diff(g, axis=axis), g[tuple(sl2)]), axis=axis)
         shape = list(ans_shape)
         shape[axis] = 1
         return anp.zeros(shape)
@@ -482,8 +482,8 @@ def tensordot_adjoint_0(B, G, axes, A_ndim, B_ndim):
         axes = [axes0, axes1]
         A_axes = onp.arange(A_ndim)
         B_axes = onp.arange(B_ndim)
-        summed_axes = [onp.asarray(axes[0]) % A_ndim,
-                       onp.asarray(axes[1]) % B_ndim]
+        summed_axes = [onp.asarray(axes[0], dtype='int64') % A_ndim,
+                       onp.asarray(axes[1], dtype='int64') % B_ndim]
         other_axes  = [onp.delete(A_axes, summed_axes[0]),
                        onp.delete(B_axes, summed_axes[1])]
         out = onp.tensordot(G, B, [G_axes[len(other_axes[0]):], other_axes[1]])
@@ -509,8 +509,8 @@ def tensordot_adjoint_1(A, G, axes, A_ndim, B_ndim):
         axes = [axes0, axes1]
         A_axes = onp.arange(A_ndim)
         B_axes = onp.arange(B_ndim)
-        summed_axes = [onp.asarray(axes[0]) % A_ndim,
-                       onp.asarray(axes[1]) % B_ndim]
+        summed_axes = [onp.asarray(axes[0], dtype='int64') % A_ndim,
+                       onp.asarray(axes[1], dtype='int64') % B_ndim]
         other_axes  = [onp.delete(A_axes, summed_axes[0]),
                        onp.delete(B_axes, summed_axes[1])]
         out = onp.tensordot(A, G, [other_axes[0], G_axes[:len(other_axes[0])]])
@@ -692,6 +692,8 @@ defvjp(anp._array_from_scalar_or_array, array_from_scalar_or_array_gradmaker, ar
 
 @primitive
 def untake(x, idx, vs):
+    if isinstance(idx, list) and (len(idx) == 0 or not isinstance(idx[0], slice)):
+        idx = onp.array(idx, dtype='int64')
     def mut_add(A):
         onp.add.at(A, idx, x)
         return A

--- a/autograd/scipy/stats/multivariate_normal.py
+++ b/autograd/scipy/stats/multivariate_normal.py
@@ -38,18 +38,18 @@ def solve(allow_singular):
 
 defvjp(logpdf,
        lambda ans, x, mean, cov, allow_singular=False:
-       unbroadcast_f(x, lambda g: -np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T),
+       unbroadcast_f(x, lambda g: -np.expand_dims(np.atleast_1d(g), 1) * solve(allow_singular)(cov, (x - mean).T).T),
        lambda ans, x, mean, cov, allow_singular=False:
-       unbroadcast_f(mean, lambda g:  np.expand_dims(g, 1) * solve(allow_singular)(cov, (x - mean).T).T),
+       unbroadcast_f(mean, lambda g:  np.expand_dims(np.atleast_1d(g), 1) * solve(allow_singular)(cov, (x - mean).T).T),
        lambda ans, x, mean, cov, allow_singular=False:
        unbroadcast_f(cov, lambda g: np.reshape(g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)))
 
 # Same as log pdf, but multiplied by the pdf (ans).
 defvjp(pdf,
        lambda ans, x, mean, cov, allow_singular=False:
-       unbroadcast_f(x, lambda g: -np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T),
+       unbroadcast_f(x, lambda g: -np.expand_dims(np.atleast_1d(ans * g), 1) * solve(allow_singular)(cov, (x - mean).T).T),
        lambda ans, x, mean, cov, allow_singular=False:
-       unbroadcast_f(mean, lambda g:  np.expand_dims(ans * g, 1) * solve(allow_singular)(cov, (x - mean).T).T),
+       unbroadcast_f(mean, lambda g:  np.expand_dims(np.atleast_1d(ans * g), 1) * solve(allow_singular)(cov, (x - mean).T).T),
        lambda ans, x, mean, cov, allow_singular=False:
        unbroadcast_f(cov, lambda g: np.reshape(ans * g, np.shape(g) + (1, 1)) * covgrad(x, mean, cov, allow_singular)))
 


### PR DESCRIPTION
Fixes #468. 

There is still a numpy warning about converting complex to real, and tests show a bunch of `UserWarning: Output seems independent of input` from `tracer.py`.