### PR TITLE
ENH: fix wrapper for pypy

### DIFF
--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -18,11 +18,10 @@ def wrap_intdtype(cls):
 def wrap_namespace(old, new):
     unchanged_types = {float, int, type(None), type}
     int_types = {_np.int, _np.int8, _np.int16, _np.int32, _np.int64, _np.integer}
-    function_types = {_np.ufunc, types.FunctionType, types.BuiltinFunctionType}
     for name, obj in old.items():
         if obj in notrace_functions:
             new[name] = notrace_primitive(obj)
-        elif type(obj) in function_types:
+        elif callable(obj) and type(obj) is not type:
             new[name] = primitive(obj)
         elif type(obj) is type and obj in int_types:
             new[name] = wrap_intdtype(obj)


### PR DESCRIPTION
Fixes #398 

With this and #507 I can run benchmarks with pypy and python3

```
python -m asv run --config asv.conf.json.sample --python=pypy3 pypy~1..pypy
python -m asv run --config asv.conf.json.sample --python=3.6 pypy~1..pypy
```

and (after adding this branch to the `branches` key in the config file) view the results with

```
python -m asv publish --config asv.conf.json.sample
python -m asv preview --config asv.conf.json.sample
```

Unfortunately, asv is not really set up to `compare` across pythons (see airspeed-velocity/asv#789 which I think helps) so I needed to use the web framework to be able to compare. While PyPy is slower at most benchmarks, for some it gives a noticable speedup.