### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -85,7 +85,7 @@ def grad_norm(ans, x, ord=None, axis=None):
 
     check_implemented()
     def vjp(g):
-        if ord is None or ord == 2 or ord is 'fro':
+        if ord in (None, 2, 'fro'):
             return expand(g / ans) * x
         elif ord == 'nuc':
             x_rolled = roll(x)


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals.

$ __python__
```
>>> ord = 'fr'
>>> ord += 'o'
>>> ord == 'fro'
True
>>> ord is 'fro'
False
```
[flake8](http://flake8.pycqa.org) testing of https://github.com/HIPS/autograd on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./autograd/numpy/fft.py:19:8: F821 undefined name 'fft'
defvjp(fft, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:20:32: F821 undefined name 'fft'
        fft_grad(get_fft_args, fft, *args, **kwargs))
                               ^
./autograd/numpy/fft.py:21:8: F821 undefined name 'ifft'
defvjp(ifft, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:22:32: F821 undefined name 'ifft'
        fft_grad(get_fft_args, ifft, *args, **kwargs))
                               ^
./autograd/numpy/fft.py:24:8: F821 undefined name 'fft2'
defvjp(fft2, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:25:32: F821 undefined name 'fft2'
        fft_grad(get_fft_args, fft2, *args, **kwargs))
                               ^
./autograd/numpy/fft.py:26:8: F821 undefined name 'ifft2'
defvjp(ifft2, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:27:32: F821 undefined name 'ifft2'
        fft_grad(get_fft_args, ifft2, *args, **kwargs))
                               ^
./autograd/numpy/fft.py:29:8: F821 undefined name 'fftn'
defvjp(fftn, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:30:32: F821 undefined name 'fftn'
        fft_grad(get_fft_args, fftn, *args, **kwargs))
                               ^
./autograd/numpy/fft.py:31:8: F821 undefined name 'ifftn'
defvjp(ifftn, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:32:32: F821 undefined name 'ifftn'
        fft_grad(get_fft_args, ifftn, *args, **kwargs))
                               ^
./autograd/numpy/fft.py:72:8: F821 undefined name 'rfft'
defvjp(rfft, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:73:33: F821 undefined name 'irfft'
        rfft_grad(get_fft_args, irfft, *args, **kwargs))
                                ^
./autograd/numpy/fft.py:75:8: F821 undefined name 'irfft'
defvjp(irfft, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:76:34: F821 undefined name 'rfft'
        irfft_grad(get_fft_args, rfft, *args, **kwargs))
                                 ^
./autograd/numpy/fft.py:78:8: F821 undefined name 'rfft2'
defvjp(rfft2, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:79:34: F821 undefined name 'irfft2'
        rfft_grad(get_fft2_args, irfft2, *args, **kwargs))
                                 ^
./autograd/numpy/fft.py:81:8: F821 undefined name 'irfft2'
defvjp(irfft2, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:82:35: F821 undefined name 'rfft2'
        irfft_grad(get_fft2_args, rfft2, *args, **kwargs))
                                  ^
./autograd/numpy/fft.py:84:8: F821 undefined name 'rfftn'
defvjp(rfftn, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:85:34: F821 undefined name 'irfftn'
        rfft_grad(get_fftn_args, irfftn, *args, **kwargs))
                                 ^
./autograd/numpy/fft.py:87:8: F821 undefined name 'irfftn'
defvjp(irfftn, lambda *args, **kwargs:
       ^
./autograd/numpy/fft.py:88:35: F821 undefined name 'rfftn'
        irfft_grad(get_fftn_args, rfftn, *args, **kwargs))
                                  ^
./autograd/numpy/fft.py:90:8: F821 undefined name 'fftshift'
defvjp(fftshift,  lambda ans, x, axes=None : lambda g:
       ^
./autograd/numpy/fft.py:91:44: F821 undefined name 'ifftshift'
                 match_complex(x, anp.conj(ifftshift(anp.conj(g), axes))))
                                           ^
./autograd/numpy/fft.py:92:8: F821 undefined name 'ifftshift'
defvjp(ifftshift, lambda ans, x, axes=None : lambda g:
       ^
./autograd/numpy/fft.py:93:44: F821 undefined name 'fftshift'
                 match_complex(x, anp.conj(fftshift(anp.conj(g), axes))))
                                           ^
./autograd/numpy/numpy_jvps.py:145:39: F821 undefined name 'np'
        num_reps = anp.prod(anp.array(np.shape(g))[list(axis)])
                                      ^
./autograd/numpy/linalg.py:24:8: F821 undefined name 'det'
defvjp(det, lambda ans, x: lambda g: add2d(g) * add2d(ans) * T(inv(x)))
       ^
./autograd/numpy/linalg.py:24:64: F821 undefined name 'inv'
defvjp(det, lambda ans, x: lambda g: add2d(g) * add2d(ans) * T(inv(x)))
                                                               ^
./autograd/numpy/linalg.py:25:8: F821 undefined name 'slogdet'
defvjp(slogdet, lambda ans, x: lambda g: add2d(g[1]) * T(inv(x)))
       ^
./autograd/numpy/linalg.py:25:58: F821 undefined name 'inv'
defvjp(slogdet, lambda ans, x: lambda g: add2d(g[1]) * T(inv(x)))
                                                         ^
./autograd/numpy/linalg.py:29:8: F821 undefined name 'inv'
defvjp(inv, grad_inv)
       ^
./autograd/numpy/linalg.py:38:8: F821 undefined name 'pinv'
defvjp(pinv, grad_pinv)
       ^
./autograd/numpy/linalg.py:43:38: F821 undefined name 'solve'
        return lambda g: -_dot(updim(solve(T(a), g)), T(updim(ans)))
                                     ^
./autograd/numpy/linalg.py:45:26: F821 undefined name 'solve'
        return lambda g: solve(T(a), g)
                         ^
./autograd/numpy/linalg.py:46:8: F821 undefined name 'solve'
defvjp(solve, partial(grad_solve, 0), partial(grad_solve, 1))
       ^
./autograd/numpy/linalg.py:88:39: F632 use ==/!= to compare str, bytes, and int literals
        if ord is None or ord == 2 or ord is 'fro':
                                      ^
./autograd/numpy/linalg.py:92:24: F821 undefined name 'svd'
            u, s, vt = svd(x_rolled, full_matrices=False)
                       ^
./autograd/numpy/linalg.py:102:8: F821 undefined name 'norm'
defvjp(norm, grad_norm)
       ^
./autograd/numpy/linalg.py:115:8: F821 undefined name 'eigh'
defvjp(eigh, grad_eigh)
       ^
./autograd/numpy/linalg.py:122:32: F821 undefined name 'solve'
    solve_trans = lambda a, b: solve(T(a), b)
                               ^
./autograd/numpy/linalg.py:132:8: F821 undefined name 'cholesky'
defvjp(cholesky, grad_cholesky)
       ^
./autograd/numpy/linalg.py:142:19: F821 undefined name 'svd'
            usv = svd(a, full_matrices=False)
                  ^
./autograd/numpy/linalg.py:223:8: F821 undefined name 'svd'
defvjp(svd, grad_svd)
       ^
./autograd/numpy/numpy_wrapper.py:37:45: F821 undefined name 'ndarray'
    return _np.concatenate(args, axis).view(ndarray)
                                            ^
./autograd/numpy/numpy_wrapper.py:39:47: F821 undefined name 'atleast_2d'
vstack = row_stack = lambda tup: concatenate([atleast_2d(_m) for _m in tup], axis=0)
                                              ^
./autograd/numpy/numpy_wrapper.py:41:13: F821 undefined name 'atleast_1d'
    arrs = [atleast_1d(_m) for _m in tup]
            ^
./autograd/numpy/numpy_wrapper.py:109:12: F821 undefined name 'ndim'
        if ndim(arr) != 1:
           ^
./autograd/numpy/numpy_wrapper.py:110:19: F821 undefined name 'ravel'
            arr = ravel(arr)
                  ^
./autograd/numpy/numpy_wrapper.py:111:18: F821 undefined name 'ravel'
        values = ravel(array(values))
                 ^
./autograd/numpy/numpy_wrapper.py:112:16: F821 undefined name 'ndim'
        axis = ndim(arr) - 1
               ^
./autograd/scipy/linalg.py:14:25: F821 undefined name 'solve_sylvester'
        return anp.real(solve_sylvester(ans_transp, ans_transp, g))
                        ^
./autograd/scipy/linalg.py:16:8: F821 undefined name 'sqrtm'
defvjp(sqrtm, _vjp_sqrtm)
       ^
./autograd/scipy/linalg.py:29:18: F821 undefined name 'solve_triangular'
        v = al2d(solve_triangular(a, g, trans=_flip(a, trans), lower=lower))
                 ^
./autograd/scipy/linalg.py:33:8: F821 undefined name 'solve_triangular'
defvjp(solve_triangular,
       ^
./autograd/scipy/linalg.py:36:18: F821 undefined name 'solve_triangular'
       lambda g: solve_triangular(a, g, trans=_flip(a, trans), lower=lower))
                 ^
./autograd/scipy/linalg.py:40:12: F821 undefined name 'solve_sylvester'
    return solve_sylvester(ans, ans, dA)
           ^
./autograd/scipy/linalg.py:41:8: F821 undefined name 'sqrtm'
defjvp(sqrtm, _jvp_sqrtm)
       ^
./autograd/scipy/linalg.py:53:12: F821 undefined name 'solve_sylvester'
    return solve_sylvester(a, b, rhs)
           ^
./autograd/scipy/linalg.py:54:16: F821 undefined name 'solve_sylvester'
defjvp_argnums(solve_sylvester, _jvp_sylvester)
               ^
./autograd/scipy/linalg.py:60:17: F821 undefined name 'solve_sylvester'
        q_vjp = solve_sylvester(anp.transpose(a), anp.transpose(b), g)
                ^
./autograd/scipy/linalg.py:66:16: F821 undefined name 'solve_sylvester'
defvjp_argnums(solve_sylvester, _vjp_sylvester)
               ^
1     F632 use ==/!= to compare str, bytes, and int literals
63    F821 undefined name 'fft'
64
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree