### PR TITLE
Further correcting grad_eigh to support hermitian matrices and the UPLO kwarg properly

### DIFF
--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -117,7 +117,7 @@ def grad_eigh(ans, x, UPLO='L'):
         # Add eigenvector part only if non-zero backward signal is present.
         # This can avoid NaN results for degenerate cases if the function depends
         # on the eigenvalues only.
-        if anp.sum(anp.abs(vg)) > 1e-10:
+        if anp.any(vg):
             off_diag = anp.ones((N, N)) - anp.eye(N)
             F = off_diag / (T(w_repeated) - w_repeated + anp.eye(N))
             vjp_temp += _dot(_dot(vc, F * _dot(T(v), vg)), T(v))

--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -112,7 +112,21 @@ def grad_eigh(ans, x, UPLO='L'):
         w_repeated = anp.repeat(w[..., anp.newaxis], N, axis=-1)
         off_diag = anp.ones((N, N)) - anp.eye(N)
         F = off_diag / (T(w_repeated) - w_repeated + anp.eye(N))
-        return _dot(vc * wg[..., anp.newaxis, :] + _dot(vc, F * _dot(T(v), vg)), T(v))
+        vjp_temp = _dot(vc * wg[..., anp.newaxis, :] + _dot(vc, F * _dot(T(v), vg)), T(v))
+
+        # eigh always uses only the lower or the upper part of the matrix
+        # we also have to make sure broadcasting works
+        reps = anp.array(x.shape)
+        reps[-2:] = 1
+
+        if UPLO == 'L':
+            tri = anp.tile(anp.tril(anp.ones(N), -1), reps)
+        elif UPLO == 'U':
+            tri = anp.tile(anp.triu(anp.ones(N), 1), reps)
+        
+        return anp.real(vjp_temp)*anp.eye(vjp_temp.shape[-1]) + \
+            (vjp_temp + anp.conj(T(vjp_temp))) * tri
+
     return vjp
 defvjp(eigh, grad_eigh)
 

--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -105,12 +105,14 @@ def grad_eigh(ans, x, UPLO='L'):
     """Gradient for eigenvalues and vectors of a symmetric matrix."""
     N = x.shape[-1]
     w, v = ans              # Eigenvalues, eigenvectors.
+    vc = anp.conj(v)
+    
     def vjp(g):
         wg, vg = g          # Gradient w.r.t. eigenvalues, eigenvectors.
         w_repeated = anp.repeat(w[..., anp.newaxis], N, axis=-1)
         off_diag = anp.ones((N, N)) - anp.eye(N)
         F = off_diag / (T(w_repeated) - w_repeated + anp.eye(N))
-        return _dot(v * wg[..., anp.newaxis, :] + _dot(v, F * _dot(T(v), vg)), T(v))
+        return _dot(vc * wg[..., anp.newaxis, :] + _dot(vc, F * _dot(T(v), vg)), T(v))
     return vjp
 defvjp(eigh, grad_eigh)
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -214,7 +214,7 @@ def test_eigvalh_upper_broadcasting():
 def test_eigvalh_lower_complex():
     def fun(x):
         w, v = np.linalg.eigh(x)
-        return w
+        return tuple((w, np.abs(v)))
     D = 6
     mat = npr.randn(D, D) + 1j*npr.randn(D, D)
     check_grads(fun)(mat)
@@ -222,7 +222,7 @@ def test_eigvalh_lower_complex():
 def test_eigvalh_upper_complex():
     def fun(x):
         w, v = np.linalg.eigh(x, 'U')
-        return w
+        return tuple((w, np.abs(v)))
     D = 6
     mat = npr.randn(D, D) + 1j*npr.randn(D, D)
     check_grads(fun)(mat)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -181,8 +181,7 @@ def test_eigvalh_lower():
         return tuple((w, v))
     D = 6
     mat = npr.randn(D, D)
-    hmat = np.dot(mat.T, mat)
-    check_symmetric_matrix_grads(fun)(hmat)
+    check_grads(fun)(mat)
 
 def test_eigvalh_upper():
     def fun(x):
@@ -190,8 +189,7 @@ def test_eigvalh_upper():
         return tuple((w, v))
     D = 6
     mat = npr.randn(D, D)
-    hmat = np.dot(mat.T, mat)
-    check_symmetric_matrix_grads(fun)(hmat)
+    check_grads(fun)(mat)
 
 broadcast_dot_transpose = partial(np.einsum, '...ij,...kj->...ik')
 def test_eigvalh_lower_broadcasting():
@@ -201,7 +199,7 @@ def test_eigvalh_lower_broadcasting():
     D = 6
     mat = npr.randn(2, 3, D, D) + 10 * np.eye(D)[None,None,...]
     hmat = broadcast_dot_transpose(mat, mat)
-    check_symmetric_matrix_grads(fun)(hmat)
+    check_grads(fun)(hmat)
 
 def test_eigvalh_upper_broadcasting():
     def fun(x):
@@ -210,7 +208,24 @@ def test_eigvalh_upper_broadcasting():
     D = 6
     mat = npr.randn(2, 3, D, D) + 10 * np.eye(D)[None,None,...]
     hmat = broadcast_dot_transpose(mat, mat)
-    check_symmetric_matrix_grads(fun)(hmat)
+    check_grads(fun)(hmat)
+
+# For complex-valued matrices, the gradient only works for the eigenvalues, but not for the eigenvectors
+def test_eigvalh_lower_complex():
+    def fun(x):
+        w, v = np.linalg.eigh(x)
+        return w
+    D = 6
+    mat = npr.randn(D, D) + 1j*npr.randn(D, D)
+    check_grads(fun)(mat)
+
+def test_eigvalh_upper_complex():
+    def fun(x):
+        w, v = np.linalg.eigh(x, 'U')
+        return w
+    D = 6
+    mat = npr.randn(D, D) + 1j*npr.randn(D, D)
+    check_grads(fun)(mat)
 
 def test_cholesky():
     fun = lambda A: np.linalg.cholesky(A)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -210,7 +210,9 @@ def test_eigvalh_upper_broadcasting():
     hmat = broadcast_dot_transpose(mat, mat)
     check_grads(fun)(hmat)
 
-# For complex-valued matrices, the gradient only works for the eigenvalues, but not for the eigenvectors
+# For complex-valued matrices, the eigenvectors could have arbitrary phases (gauge)
+# which makes it impossible to compare to numerical derivatives. So we take the 
+# absolute value to get rid of that phase. 
 def test_eigvalh_lower_complex():
     def fun(x):
         w, v = np.linalg.eigh(x)


### PR DESCRIPTION
*Edit: as discussed in the comments below, the issue with the complex eigenvectors is the gauge, which is arbitrary. However, this updated code should work for complex-valued matrices and functions that do not depend on the gauge. So for example, the test for the complex case uses `np.abs(v)`.*

What this update does:
- fix the vjp computation for numpy.linalg.eigh in accordance with the behavior of the function, which *always* takes *only* the upper/lower part of the matrix
- fix the tests to take random matrices as opposed to random symmetric matrices
- fix the computation to work for Hermitian matrices as per [this](https://github.com/HIPS/autograd/pull/462) pull request, on which I've built

However:
- the gradient for Hermitian matrices works only for the eigenvalues and not (always) for the eigenvectors
- so I've added a test, but I take a random complex matrix and check *only* the eigenvalue gradient flow
- the problem with eigenvectors probably has to do with their being complex; this has not been dealt with anywhere that I looked: (pyTorch, TensorFlow, or the original reference https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf , where real eigenvectors are also assumed to be real in the tests)

The gradient for the eigenvectors does not pass a general test. However, it works in some cases. For example, this code

```
import autograd.numpy as npa
from autograd import grad

def fn(a):
    # Define an array with some random operations 
    mat = npa.array([[(1+1j)*a, 2, a], 
                    [1j*a, 2 + npa.abs(a + 1j), 1], 
                    [npa.conj(a), npa.exp(a), npa.abs(a)]])
    [eigs, vs] = npa.linalg.eigh(mat)
    return npa.abs(vs[0, 0])

a = 2.1 + 1.1j # Some random test value

# Compute the numerical gradient of fn(a)
grad_num = (fn(a + 1e-5)-fn(a))/1e-5 - 1j*(fn(a + 1e-5*1j)-fn(a))/1e-5

print('Autograd gradient:  ', grad(fn)(a))
print('Numerical gradient: ', grad_num)
print('Difference:         ', npa.linalg.norm(grad(fn)(a)-grad_num))
```

returns a difference smaller than 1e-6 for any individual component of `vs` that is put in the return statement. However, it breaks for a more complicated function, e.g. `return npa.abs(vs[0, 0] + vs[1, 1])`.

It would be great if someone can address this further. Still, for now this PR is a significant improvement in the behavior of the `linalg.eigh` function.