### PR TITLE
Introducing numerical vjp's in the gradient computation

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -3,7 +3,6 @@ from functools import reduce
 from .tracer import trace, primitive, toposort, Node, Box, isbox, getval
 from .util import func, subval
 
-import numpy as np
 
 # -------------------- reverse mode --------------------
 

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -3,6 +3,8 @@ from functools import reduce
 from .tracer import trace, primitive, toposort, Node, Box, isbox, getval
 from .util import func, subval
 
+import numpy as np
+
 # -------------------- reverse mode --------------------
 
 def make_vjp(fun, x):
@@ -89,6 +91,41 @@ def translate_vjp(vjpfun, fun, argnum):
         return vjpfun
     else:
         raise Exception("Bad VJP '{}' for '{}'".format(vjpfun, fun.__name__))
+
+def vjp_numeric(fun, argnum, step=1e-6, mode='centered'):
+    """ Evaluatest the vector-jacobian product numerically, using a step size
+    `step` to evaluate the jacobian. """
+
+    def vjpfun(ans, *args, **kwargs):
+        arg = args[argnum]
+        arg_vs = vspace(arg)
+        shape = arg_vs.shape
+        num_p = arg_vs.size
+        fn_vs = vspace(ans)
+
+        def vjp(v):
+            vjp_num = arg_vs.zeros()
+            for ip in range(int(num_p)):
+                if mode == 'forward':
+                    args_for = list(args)
+                    args_for[argnum] = arg_vs.add(arg, arg_vs.scalar_mul(arg_vs.one_ind(ip), step))
+                    fn_for = fun(*args_for, **kwargs)
+                    neg_ans = fn_vs.scalar_mul(ans, -1.0)  
+                    dfn_dp = fn_vs.scalar_mul(fn_vs.add(fn_for, neg_ans), 1.0/step)
+                elif mode == 'centered':
+                    args_for = list(args)
+                    args_for[argnum] = arg_vs.add(arg, arg_vs.scalar_mul(arg_vs.one_ind(ip), step/2))
+                    fn_for = fun(*args_for, **kwargs)
+                    args_back = list(args)
+                    args_back[argnum] = arg_vs.add(arg, arg_vs.scalar_mul(arg_vs.one_ind(ip), -step/2))
+                    fn_back = fun(*args_back, **kwargs)
+                    neg_fn_back = fn_vs.scalar_mul(fn_back, -1.0)                
+                    dfn_dp = fn_vs.scalar_mul(fn_vs.add(fn_for, neg_fn_back), 1.0/step)
+                
+                vjp_num[arg_vs.one_ind(ip)==1.] = arg_vs.inner_prod(v, dfn_dp)
+            return vjp_num
+        return vjp
+    return vjpfun
 
 # -------------------- forward mode --------------------
 

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -3,7 +3,6 @@ from functools import reduce
 from .tracer import trace, primitive, toposort, Node, Box, isbox, getval
 from .util import func, subval
 
-
 # -------------------- reverse mode --------------------
 
 def make_vjp(fun, x):

--- a/autograd/extend.py
+++ b/autograd/extend.py
@@ -2,4 +2,4 @@
 from .tracer import Box, primitive, register_notrace, notrace_primitive
 from .core import (SparseObject, VSpace, vspace, VJPNode, JVPNode,
                    defvjp_argnums, defvjp_argnum, defvjp,
-                   defjvp_argnums, defjvp_argnum, defjvp, def_linear)
+                   defjvp_argnums, defjvp_argnum, defjvp, def_linear, vjp_numeric)

--- a/autograd/numpy/numpy_vspaces.py
+++ b/autograd/numpy/numpy_vspaces.py
@@ -13,6 +13,10 @@ class ArrayVSpace(VSpace):
     def ndim(self): return len(self.shape)
     def zeros(self): return np.zeros(self.shape, dtype=self.dtype)
     def ones(self):  return np.ones( self.shape, dtype=self.dtype)
+    def one_ind(self, ind):
+      out = np.zeros(self.shape, dtype=self.dtype)
+      out[np.unravel_index(ind, shape=self.shape)] = np.array([1.]).astype(dtype=self.dtype)
+      return out
 
     def standard_basis(self):
       for idxs in np.ndindex(*self.shape):


### PR DESCRIPTION
This is a preliminary PR as I would like to hear your feedback on the following idea and its implementation. Sometimes, it might be useful to incorporate a numerically computed derivative in the automatic differentiation process. For example, assume we have the following flow

```
def fun(x):
   y = f1(x)
   z = g(y)
   return f2(z)
```

where `f1(x)` and `f2(x)` can be handled by `autograd` but `g(y)` has not been implemented. If `g(y)` is fast to compute and/or if the size of `y` is small, we could compute the associated vjp by numerically computing the jacobian of `g(y)`. Specifically, this requires `2 * y.size` evaluations of `g(y)` if the centered finite-difference is computed, or just `y.size` evaluations for forward difference. This is obviously going to be prohibitively expensive in some cases, but in others it might come in handy.

Particular use cases that come to mind include:
- When `g(y)` is one of the numpy/scipy functions which has not yet been implemented in autograd.
- When `g(y)` is some user-defined function for which an analytic `vjp` is unknown or too tedious to implement.
- Potentially, when `g(y)` is not even différentiable (e.g. discontinuous), but a numerical derivative could still be of some use (this is a bit more speculative). 

I have implemented a function `vjp_numeric` in `autograd.core` that allows the user to do what I describe above. Here is a simple example along the lines of the autograd tutorial:

```
import autograd.numpy as np
from autograd import grad
from autograd.extend import primitive, defvjp, vjp_numeric

@primitive
def logsumexp(x):
    """Numerically stable log(sum(exp(x)))"""
    max_x = np.max(x)
    return max_x + np.log(np.sum(np.exp(x - max_x)))

def logsumexp_vjp(ans, x):
    x_shape = x.shape
    return lambda g: np.full(x_shape, g) * np.exp(x - np.full(x_shape, ans))

# Random input
x = np.random.rand(4)

# First compute analytic gradient
defvjp(logsumexp, logsumexp_vjp)
grad_analytic = grad(logsumexp)(x)

# Then compute numeric gradient
logsumexp_vjp_num = vjp_numeric(logsumexp, 0)
defvjp(logsumexp, logsumexp_vjp_num)
grad_numeric = grad(logsumexp)(x)

print('Analytic gradient :', grad_analytic)
print('Numeric gradient  :', grad_numeric)
```

Output:

```
Analytic gradient : [0.2806353  0.3378267  0.14405427 0.23748373]
Numeric gradient  : [0.2806353  0.3378267  0.14405427 0.23748373]
```

And here is a more useful example: the gradient of `numpy.linalg.lstsq` is currently not implemented. This can be circumvented using the new functionality.

```
import numpy as np
import autograd.numpy as npa
from autograd import grad
from autograd.extend import primitive, defvjp, vjp_numeric

@primitive
def lstsq(*args, **kwargs):
    return np.linalg.lstsq(*args, **kwargs)[0]

vjp_lstsq_0 = vjp_numeric(lstsq, 0)
vjp_lstsq_1 = vjp_numeric(lstsq, 1)

defvjp(lstsq, vjp_lstsq_0, vjp_lstsq_1)

def linreg_slope(x, y):
    A = npa.vstack([x, npa.ones(len(x))]).T
    m, c = lstsq(A, y, rcond=None)
    return m

x = np.array([0, 1, 2, 3])
y = np.array([-1, 0.2, 0.7, 2.5])

print('Slope of linear fit of y vs. x :', linreg_slope(x, y))
print('Gradient of slope w.r.t. x     :', grad(linreg_slope, 0)(x, y))
print('Gradient of slope w.r.t. y     :', grad(linreg_slope, 1)(x, y))
```

Output:

```
Slope of linear fit of y vs. x : 1.0999999999999994
Gradient of slope w.r.t. x     : [ 0.34  0.14 -0.2  -0.28]
Gradient of slope w.r.t. y     : [-0.3 -0.1  0.1  0.3]
```

There is some more work that can be put into this (most notably, currently it only works for real numbers, not complex). Before that, however, I have two questions:

- Is this of interest?
- Do you have remarks on the approach I'm taking in implementing it?