### PR TITLE
Fix complex valued svd backpropagation.

### DIFF
--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -18,6 +18,9 @@ def T(x): return anp.swapaxes(x, -1, -2)
 
 _dot = partial(anp.einsum, '...ij,...jk->...ik')
 
+# batched diag 
+_diag = lambda a: anp.eye(a.shape[-1])*a 
+
 # add two dimensions to the end of x
 def add2d(x): return anp.reshape(x, anp.shape(x) + (1, 1))
 
@@ -155,6 +158,8 @@ def grad_cholesky(L, A):
     return vjp
 defvjp(cholesky, grad_cholesky)
 
+# https://j-towns.github.io/papers/svd-derivative.pdf
+# https://arxiv.org/abs/1909.02659
 def grad_svd(usv_, a, full_matrices=True, compute_uv=True):
     def vjp(g):
         usv = usv_
@@ -190,41 +195,21 @@ def grad_svd(usv_, a, full_matrices=True, compute_uv=True):
             gs = g[1]
             gv = anp.conj(T(g[2]))
 
-            """
-            utgu = _dot(T(u), gu)
-            vtgv = _dot(T(v), gv)
-            t1 = (f * (utgu - T(utgu))) * s[..., anp.newaxis, :]
-            t1 = t1 + i * gs[..., :, anp.newaxis]
-            t1 = t1 + s[..., :, anp.newaxis] * (f * (vtgv - T(vtgv)))
-
-            t1 = _dot(_dot(u, t1), T(v))
-            """
             utgu = _dot(T(u), gu)
             vtgv = _dot(T(v), gv)
             t1 = (f * (utgu - anp.conj(T(utgu)))) * s[..., anp.newaxis, :]
             t1 = t1 + i * gs[..., :, anp.newaxis]
             t1 = t1 + s[..., :, anp.newaxis] * (f * (vtgv - anp.conj(T(vtgv)))) 
 
-            """
-            utgu = _dot(T(u), gu)
-            J = f*utgu
-            J = J + anp.conj(T(J))
-            K = f*_dot(T(v), gv)
-            K = K + anp.conj(T(K))
-  
-            t1 = J * s[..., anp.newaxis, :]
-            t1 = t1 + i * gs[..., :, anp.newaxis]
-            t1 = t1 + s[..., :, anp.newaxis] * K
-            """
             if anp.iscomplexobj(u):
-                t1 = t1 + anp.diag(1j*anp.imag(anp.diag(utgu)) / s)
-            t1 = _dot(_dot(anp.conj(u), t1), T(v))
+                t1 = t1 + 1j*anp.imag(_diag(utgu)) / s[..., anp.newaxis, :]
 
+            t1 = _dot(_dot(anp.conj(u), t1), T(v))
 
             if m < n:
                 i_minus_vvt = (anp.reshape(anp.eye(n), anp.concatenate((anp.ones(a.ndim - 2, dtype=int), (n, n)))) -
-                                _dot(v, T(v)))
-                t1 = t1 + _dot(_dot(u / s[..., anp.newaxis, :], T(gv)), i_minus_vvt)
+                                _dot(v, anp.conj(T(v))))
+                t1 = t1 + anp.conj(_dot(_dot(u / s[..., anp.newaxis, :], T(gv)), i_minus_vvt))
 
                 return t1
 
@@ -233,8 +218,8 @@ def grad_svd(usv_, a, full_matrices=True, compute_uv=True):
 
             elif m > n:
                 i_minus_uut = (anp.reshape(anp.eye(m), anp.concatenate((anp.ones(a.ndim - 2, dtype=int), (m, m)))) -
-                                _dot(u, T(u)))
-                t1 = t1 + _dot(i_minus_uut, _dot(gu, T(v) / s[..., :, anp.newaxis]))
+                                _dot(u, anp.conj(T(u))))
+                t1 = t1 + T(_dot(_dot(v/s[..., anp.newaxis, :], T(gu)), i_minus_uut) )
 
                 return t1
     return vjp

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -277,6 +277,26 @@ def test_svd_square_2d():
     mat = npr.randn(m, n)
     check_grads(fun)(mat)
 
+def test_svd_wide_2d_complex():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((np.abs(u), s, np.abs(v)))
+        return grad(fun)(x)
+    m = 3
+    n = 5
+    mat = npr.randn(m, n) + 1j * npr.randn(m, n)
+    check_grads(fun)(mat)
+
+def test_svd_tall_2d_complex():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((np.abs(u), s, np.abs(v)))
+        return grad(fun)(x)
+    m = 5
+    n = 3
+    mat = npr.randn(m, n) + 1j * npr.randn(m, n)
+    check_grads(fun)(mat)
+
 def test_svd_square_2d_complex():
     def fun(x):
         u, s, v = np.linalg.svd(x, full_matrices=False)
@@ -323,7 +343,32 @@ def test_svd_tall_3d():
     mat = npr.randn(k, m, n)
     check_grads(fun)(mat)
 
-"""
+def test_svd_tall_3d_complex():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((np.abs(u), s, np.abs(v)))
+        return grad(fun)(x)
+
+    k = 4
+    m = 5
+    n = 3
+
+    mat = npr.randn(k, m, n) + 1j* npr.randn(k, m, n)
+    check_grads(fun)(mat)
+
+def test_svd_wide_3d_complex():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((np.abs(u), s, np.abs(v)))
+        return grad(fun)(x)
+
+    k = 4
+    m = 3
+    n = 5
+
+    mat = npr.randn(k, m, n) + 1j* npr.randn(k, m, n)
+    check_grads(fun)(mat)
+
 def test_svd_only_s_2d():
     np.random.seed(2)
     def fun(x):
@@ -335,7 +380,18 @@ def test_svd_only_s_2d():
     n = 3
     mat = npr.randn(m, n)
     check_grads(fun)(mat)
-"""
+
+def test_svd_only_s_2d_complex():
+    np.random.seed(2)
+    def fun(x):
+        s = np.linalg.svd(x, full_matrices=False, compute_uv=False)
+        return s
+        return grad(fun)(x)
+
+    m = 5
+    n = 3
+    mat = npr.randn(m, n) + 1J* npr.randn(m, n)
+    check_grads(fun)(mat)
 
 def test_svd_only_s_3d():
     def fun(x):
@@ -348,4 +404,17 @@ def test_svd_only_s_3d():
     n = 3
 
     mat = npr.randn(k, m, n)
+    check_grads(fun)(mat)
+
+def test_svd_only_s_3d_complex():
+    def fun(x):
+        s = np.linalg.svd(x, full_matrices=False, compute_uv=False)
+        return s
+        return grad(fun)(x)
+
+    k = 4
+    m = 5
+    n = 3
+
+    mat = npr.randn(k, m, n) + 1J* npr.randn(k, m, n)
     check_grads(fun)(mat)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -254,29 +254,6 @@ def test_svd_wide_2d():
     mat = npr.randn(m, n)
     check_grads(fun)(mat)
 
-def test_svd_wide_3d():
-    def fun(x):
-        u, s, v = np.linalg.svd(x, full_matrices=False)
-        return tuple((u, s, v))
-        return grad(fun)(x)
-
-    k = 4
-    m = 3
-    n = 5
-
-    mat = npr.randn(k, m, n)
-    check_grads(fun)(mat)
-
-def test_svd_square_2d():
-    def fun(x):
-        u, s, v = np.linalg.svd(x, full_matrices=False)
-        return tuple((u, s, v))
-        return grad(fun)(x)
-    m = 4
-    n = 4
-    mat = npr.randn(m, n)
-    check_grads(fun)(mat)
-
 def test_svd_wide_2d_complex():
     def fun(x):
         u, s, v = np.linalg.svd(x, full_matrices=False)
@@ -287,14 +264,38 @@ def test_svd_wide_2d_complex():
     mat = npr.randn(m, n) + 1j * npr.randn(m, n)
     check_grads(fun)(mat)
 
-def test_svd_tall_2d_complex():
+def test_svd_wide_3d():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((u, s, v))
+        return grad(fun)(x)
+
+    k = 4
+    m = 3
+    n = 5
+    mat = npr.randn(k, m, n)
+    check_grads(fun)(mat)
+
+def test_svd_wide_3d_complex():
     def fun(x):
         u, s, v = np.linalg.svd(x, full_matrices=False)
         return tuple((np.abs(u), s, np.abs(v)))
         return grad(fun)(x)
-    m = 5
-    n = 3
-    mat = npr.randn(m, n) + 1j * npr.randn(m, n)
+
+    k = 4
+    m = 3
+    n = 5
+    mat = npr.randn(k, m, n) + 1j* npr.randn(k, m, n)
+    check_grads(fun)(mat)
+
+def test_svd_square_2d():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((u, s, v))
+        return grad(fun)(x)
+    m = 4
+    n = 4
+    mat = npr.randn(m, n)
     check_grads(fun)(mat)
 
 def test_svd_square_2d_complex():
@@ -316,8 +317,19 @@ def test_svd_square_3d():
     k = 3
     m = 4
     n = 4
-
     mat = npr.randn(k, m, n)
+    check_grads(fun)(mat)
+
+def test_svd_square_3d_complex():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((np.abs(u), s, np.abs(v)))
+        return grad(fun)(x)
+
+    k = 3
+    m = 4
+    n = 4
+    mat = npr.randn(k, m, n) + 1j * npr.randn(k, m, n)
     check_grads(fun)(mat)
 
 def test_svd_tall_2d():
@@ -330,6 +342,16 @@ def test_svd_tall_2d():
     mat = npr.randn(m, n)
     check_grads(fun)(mat)
 
+def test_svd_tall_2d_complex():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((np.abs(u), s, np.abs(v)))
+        return grad(fun)(x)
+    m = 5
+    n = 3
+    mat = npr.randn(m, n) + 1j * npr.randn(m, n)
+    check_grads(fun)(mat)
+
 def test_svd_tall_3d():
     def fun(x):
         u, s, v = np.linalg.svd(x, full_matrices=False)
@@ -339,7 +361,6 @@ def test_svd_tall_3d():
     k = 4
     m = 5
     n = 3
-
     mat = npr.randn(k, m, n)
     check_grads(fun)(mat)
 
@@ -352,25 +373,10 @@ def test_svd_tall_3d_complex():
     k = 4
     m = 5
     n = 3
-
-    mat = npr.randn(k, m, n) + 1j* npr.randn(k, m, n)
-    check_grads(fun)(mat)
-
-def test_svd_wide_3d_complex():
-    def fun(x):
-        u, s, v = np.linalg.svd(x, full_matrices=False)
-        return tuple((np.abs(u), s, np.abs(v)))
-        return grad(fun)(x)
-
-    k = 4
-    m = 3
-    n = 5
-
     mat = npr.randn(k, m, n) + 1j* npr.randn(k, m, n)
     check_grads(fun)(mat)
 
 def test_svd_only_s_2d():
-    np.random.seed(2)
     def fun(x):
         s = np.linalg.svd(x, full_matrices=False, compute_uv=False)
         return s
@@ -382,7 +388,6 @@ def test_svd_only_s_2d():
     check_grads(fun)(mat)
 
 def test_svd_only_s_2d_complex():
-    np.random.seed(2)
     def fun(x):
         s = np.linalg.svd(x, full_matrices=False, compute_uv=False)
         return s
@@ -390,7 +395,7 @@ def test_svd_only_s_2d_complex():
 
     m = 5
     n = 3
-    mat = npr.randn(m, n) + 1J* npr.randn(m, n)
+    mat = npr.randn(m, n) + 1j* npr.randn(m, n)
     check_grads(fun)(mat)
 
 def test_svd_only_s_3d():
@@ -402,7 +407,6 @@ def test_svd_only_s_3d():
     k = 4
     m = 5
     n = 3
-
     mat = npr.randn(k, m, n)
     check_grads(fun)(mat)
 
@@ -415,6 +419,5 @@ def test_svd_only_s_3d_complex():
     k = 4
     m = 5
     n = 3
-
-    mat = npr.randn(k, m, n) + 1J* npr.randn(k, m, n)
+    mat = npr.randn(k, m, n) + 1j* npr.randn(k, m, n)
     check_grads(fun)(mat)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -277,6 +277,16 @@ def test_svd_square_2d():
     mat = npr.randn(m, n)
     check_grads(fun)(mat)
 
+def test_svd_square_2d_complex():
+    def fun(x):
+        u, s, v = np.linalg.svd(x, full_matrices=False)
+        return tuple((np.abs(u), s, np.abs(v)))
+        return grad(fun)(x)
+    m = 4
+    n = 4
+    mat = npr.randn(m, n) + 1j * npr.randn(m, n)
+    check_grads(fun)(mat)
+
 def test_svd_square_3d():
     def fun(x):
         u, s, v = np.linalg.svd(x, full_matrices=False)
@@ -313,7 +323,9 @@ def test_svd_tall_3d():
     mat = npr.randn(k, m, n)
     check_grads(fun)(mat)
 
+"""
 def test_svd_only_s_2d():
+    np.random.seed(2)
     def fun(x):
         s = np.linalg.svd(x, full_matrices=False, compute_uv=False)
         return s
@@ -323,6 +335,7 @@ def test_svd_only_s_2d():
     n = 3
     mat = npr.randn(m, n)
     check_grads(fun)(mat)
+"""
 
 def test_svd_only_s_3d():
     def fun(x):


### PR DESCRIPTION
The original svd_grad function doesn't work for complex valued matrices. Have fixed it according to the discussion in https://github.com/tensorflow/tensorflow/issues/13641.

I will add more test.