### PR TITLE
Reshape jacobian of real input and complex output to ensure complex output

### DIFF
--- a/autograd/differential_operators.py
+++ b/autograd/differential_operators.py
@@ -58,10 +58,22 @@ def jacobian(fun, x):
     (out1, out2, ...) then the Jacobian has shape (out1, out2, ..., in1, in2, ...).
     """
     vjp, ans = _make_vjp(fun, x)
+    x_vspace = vspace(x)
     ans_vspace = vspace(ans)
-    jacobian_shape = ans_vspace.shape + vspace(x).shape
+    jacobian_shape = ans_vspace.shape + x_vspace.shape
     grads = map(vjp, ans_vspace.standard_basis())
-    return np.reshape(np.stack(grads), jacobian_shape)
+    grads = np.stack(grads)
+
+    if (ans_vspace.iscomplex) and (not x_vspace.iscomplex):
+        # Reshape with doubled size of flattened grad (2*ans.size,x.size) due to complex fun and real x
+        jacobian_reshape = ans_vspace.shape + (2,) + x_vspace.shape
+        jacobian_moveaxis = (ans_vspace.ndim,0)
+        grads = np.moveaxis(np.reshape(grads, jacobian_reshape), *jacobian_moveaxis)
+
+        # Return complex components of jacobian
+        return grads[0] - 1j*grads[1]
+    else:
+        return np.reshape(grads, jacobian_shape)
 
 @unary_to_nary
 def holomorphic_grad(fun, x):


### PR DESCRIPTION
Reshape jacobian of real input and complex output to ensure complex output
- Currently jacobian() _make_vjp(fun,x) for real inputs and complex outputs yields grads with shape (ans.size*2,x.size), which is unable to be reshaped into jacobian_shape = (*ans.shape,*x.shape)
- jacobian() to include checks for real inputs and complex outputs (other combinations of input/output dtypes to be included)
- reshapes and transposes are done on grads to extract real and imaginary components of complex fun grads 
- grads are recombined into complex number: grads.real - 1j*grads.imag (where the -1j convention is believed to be due to the form of the vjp)
- Tested personally on fun(x) with arbitrary x and fun shape
- CI unit tests to be conducted by admins, to include holomorphic/non-holomorphic checks etc. Thank you