### PR TITLE
Fix differentiation of linalg functions broken since numpy 1.25

### DIFF
--- a/autograd/core.py
+++ b/autograd/core.py
@@ -228,9 +228,16 @@ class VSpace(object):
         else:
             VSpace.mappings[value_type] = cls
 
+def VSpace_mappings(obj):
+    for key in VSpace.mappings:
+        if isinstance(obj, key):
+            return VSpace.mappings[key]
+    else:
+        raise KeyError("Can't differentiate w.r.t. type {}".format(type(obj)))
+
 def vspace(value):
     try:
-        return VSpace.mappings[type(value)](value)
+        return VSpace_mappings(value)(value)
     except KeyError:
         if isbox(value):
             return vspace(getval(value))

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -228,23 +228,20 @@ class VSpace(object):
         else:
             VSpace.mappings[value_type] = cls
 
-def VSpace_mappings(obj):
-    for key in VSpace.mappings:
-        if isinstance(obj, key):
-            return VSpace.mappings[key]
-    else:
-        raise KeyError("Can't differentiate w.r.t. type {}".format(type(obj)))
-
 def vspace(value):
     try:
-        return VSpace_mappings(value)(value)
+        return VSpace.mappings[type(value)](value)
     except KeyError:
         if isbox(value):
             return vspace(getval(value))
         else:
-            raise TypeError("Can't find vector space for value {} of type {}. "
-                            "Valid types are {}".format(
-                                value, type(value), VSpace.mappings.keys()))
+            for key in VSpace.mappings:
+                if isinstance(value, key):
+                    return VSpace.mappings[key](value)
+            else:
+                raise TypeError("Can't find vector space for value {} of type {}. "
+                                "Valid types are {}".format(
+                                    value, type(value), VSpace.mappings.keys()))
 
 class SparseBox(Box):
     __slots__ = []

--- a/autograd/tracer.py
+++ b/autograd/tracer.py
@@ -112,18 +112,17 @@ class Box(object):
         Box.type_mappings[value_type] = cls
         Box.type_mappings[cls] = cls
 
-def box_type_mappings(obj):
-    for key in Box.type_mappings:
-        if isinstance(obj, key):
-            return Box.type_mappings[key]
-    else:
-        raise KeyError("Can't differentiate w.r.t. type {}".format(type(obj)))
+box_type_mappings = Box.type_mappings
 
 def new_box(value, trace, node):
     try:
-        return box_type_mappings(value)(value, trace, node)
+        return box_type_mappings[type(value)](value, trace, node)
     except KeyError:
-        raise TypeError("Can't differentiate w.r.t. type {}".format(type(value)))
+        for key in Box.type_mappings:
+            if isinstance(value, key):
+                return Box.type_mappings[key](value, trace, node)
+        else:
+            raise TypeError("Can't differentiate w.r.t. type {}".format(type(value)))
 
 box_types = Box.types
 isbox  = lambda x: type(x) in box_types  # almost 3X faster than isinstance(x, Box)

--- a/autograd/tracer.py
+++ b/autograd/tracer.py
@@ -112,10 +112,16 @@ class Box(object):
         Box.type_mappings[value_type] = cls
         Box.type_mappings[cls] = cls
 
-box_type_mappings = Box.type_mappings
+def box_type_mappings(obj):
+    for key in Box.type_mappings:
+        if isinstance(obj, key):
+            return Box.type_mappings[key]
+    else:
+        raise KeyError("Can't differentiate w.r.t. type {}".format(type(obj)))
+
 def new_box(value, trace, node):
     try:
-        return box_type_mappings[type(value)](value, trace, node)
+        return box_type_mappings(value)(value, trace, node)
     except KeyError:
         raise TypeError("Can't differentiate w.r.t. type {}".format(type(value)))
 


### PR DESCRIPTION
Following up on @asmeurer comment [in #597](https://github.com/HIPS/autograd/issues/597#issuecomment-1601350536) I found a way to resolve the issue by replacing the `mapping` dictionaries with functions that accept subclasses. The minimal example I gave in #597 works now with numpy 1.25.

I am sure this is not the most elegant solution (I did not look into [functools.singledispatch](https://docs.python.org/3/library/functools.html#functools.singledispatch) yet) but I think it is now clear what caused the issue. I am happy to refine this PR if someone has an idea for a more elegant mapping method.