### PR TITLE
Fix GHA pipeline, install scipy using conda

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,12 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install build tools
+    - name: Install Python build tools
+      if: matrix.python-version != 'pypy-3.7' || matrix.platform != 'windows-latest'
       run: python -m pip install tox-gh-actions wheel
+    - name: Workaround for PyPy 3.7 on Windows (tox-conda)
+      if: matrix.python-version == 'pypy-3.7' && matrix.platform == 'windows-latest'
+      run: python -m pip install tox-conda tox-gh-actions wheel
     - name: Install optional dependencies (extras) on Linux/macOS
       if: ${{ matrix.extras != 'none' && matrix.platform != 'windows-latest' }}
       run: conda install -c anaconda ${{ matrix.extras }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,19 +19,16 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - ubuntu-20.04
+        - ubuntu-latest
         - macos-latest
         - windows-latest
         python-version:
-        - '2.7'
-        - '3.5'
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
-        - pypy-2.7
+        - pypy-3.7
         - pypy-3.8
         - pypy-3.9
         extras:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install build tools
       run: python -m pip install tox-gh-actions wheel
-    - name: Install optional dependencies (extras)
+    - name: Install optional dependencies (extras) on Linux/macOS
+      if: ${{ matrix.extras != 'none' && matrix.platform != 'windows-latest' }}
       run: conda install -c anaconda ${{ matrix.extras }}
-      if: ${{ matrix.extras != 'none' }}
+    - name: Install optional dependencies (extras) on Windows
+      if: ${{ matrix.extras != 'none' && matrix.platform == 'windows-latest' }}
+      run: . ${env:CONDA}\scripts\conda.exe install -c anaconda ${{ matrix.extras }}
     - name: Run tests
       run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,10 +46,10 @@ jobs:
       if: matrix.python-version == 'pypy-3.7' && matrix.platform == 'windows-latest'
       run: python -m pip install tox-conda tox-gh-actions wheel
     - name: Install optional dependencies (extras) on Linux/macOS
-      if: ${{ matrix.extras != 'none' && matrix.platform != 'windows-latest' }}
+      if: matrix.extras != 'none' && matrix.platform != 'windows-latest'
       run: conda install -c anaconda ${{ matrix.extras }}
     - name: Install optional dependencies (extras) on Windows
-      if: ${{ matrix.extras != 'none' && matrix.platform == 'windows-latest' }}
+      if: matrix.extras != 'none' && matrix.platform == 'windows-latest'
       run: . ${env:CONDA}\scripts\conda.exe install -c anaconda ${{ matrix.extras }}
     - name: Run tests
       run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         - pypy-2.7
         - pypy-3.8
         - pypy-3.9
-        dependencies:
+        extras:
         - none
         - scipy
     steps:
@@ -44,8 +44,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install build tools
       run: python -m pip install tox-gh-actions wheel
-    - name: Install optional dependencies
-      run: python -m pip install ${{ matrix.dependencies }}
-      if: ${{ matrix.dependencies != 'none' }}
+    - name: Install optional dependencies (extras)
+      run: conda install -c anaconda ${{ matrix.extras }}
+      if: ${{ matrix.extras != 'none' }}
     - name: Run tests
       run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ commands =
     coverage run -m pytest {posargs}
     coverage xml
     coverage report
-extras = scipy
 
 [testenv:clean]
 description = Clean up bytecode and build artifacts


### PR DESCRIPTION
Installing scipy with Pip requires a few prerequisites on the various target platforms. Alternatively, using Conda makes things easier. See [StackOverflow](https://stackoverflow.com/questions/26575587/cant-install-scipy-through-pip) for a related discussion.

This is a follow-up on #602.