### PR TITLE
Install extras for testing via Tox, test with SciPy+PyPy only on Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,25 +31,18 @@ jobs:
         - pypy-3.7
         - pypy-3.8
         - pypy-3.9
-        extras:
-        - none
-        - scipy
+        - pypy-3.10
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python build tools
-      if: matrix.python-version != 'pypy-3.7' || matrix.platform != 'windows-latest'
-      run: python -m pip install tox-gh-actions wheel
-    - name: Workaround for PyPy 3.7 on Windows (tox-conda)
-      if: matrix.python-version == 'pypy-3.7' && matrix.platform == 'windows-latest'
-      run: python -m pip install tox-conda tox-gh-actions wheel
-    - name: Install optional dependencies (extras) on Linux/macOS
-      if: matrix.extras != 'none' && matrix.platform != 'windows-latest'
-      run: conda install -c anaconda ${{ matrix.extras }}
-    - name: Install optional dependencies (extras) on Windows
-      if: matrix.extras != 'none' && matrix.platform == 'windows-latest'
-      run: . ${env:CONDA}\scripts\conda.exe install -c anaconda ${{ matrix.extras }}
+      run: python -m pip install tox wheel
     - name: Run tests
-      run: tox
+      run: tox run -e py
+    - name: Install Scipy prerequisites for Ubuntu
+      if: startsWith(matrix.platform, 'ubuntu')
+      run: sudo apt-get install libopenblas-dev
+    - name: Run tests with scipy
+      run: tox run -e py-scipy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         - pypy-3.8
         - pypy-3.9
         - pypy-3.10
+        exclude:
+        - { platform: windows-latest, python-version: pypy-3.7 }
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -45,4 +47,5 @@ jobs:
       if: startsWith(matrix.platform, 'ubuntu')
       run: sudo apt-get install libopenblas-dev
     - name: Run tests with scipy
+      if: startsWith(matrix.platform, 'ubuntu') || startsWith(matrix.python-version, 'pypy') != true
       run: tox run -e py-scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=63"]
+requires = ["setuptools>=44"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tox.ini
+++ b/tox.ini
@@ -4,26 +4,13 @@
 [tox]
 envlist =
     ruff
-    py2{7}
-    pypy2{7}
-    py3{5,6,7,8,9,10,11}
-    pypy3{8,9}
+    py2{7}{,-scipy}
+    pypy2{7}{,-scipy}
+    py3{5,6,7,8,9,10,11}{,-scipy}
+    pypy3{8,9,10}{,-scipy}
     package
     clean
-
-[gh-actions]
-python =
-    2.7: py27
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    pypy-2.7: pypy27
-    pypy-3.8: pypy38
-    pypy-3.9: pypy39
+requires = virtualenv<20.22.0
 
 [testenv]
 description = Unit tests and test coverage
@@ -32,6 +19,8 @@ deps =
     pypy27: mock
     coverage[toml]
     pytest
+extras =
+    scipy: scipy
 commands =
     coverage run -m pytest {posargs}
     coverage xml


### PR DESCRIPTION
Installing extras via Conda while Tox would use Pip + virtualenv proves to be brittle. We'll factor `scipy` into the list of Tox environments instead, which will also make the test setup more straight-forward, less complex to understand and able to entirely run locally.

<details>
  <summary>Tox environments available now (click to expand)</summary>

```console
$ tox list
default environments:
ruff          -> Lightening-fast linting for Python
py27          -> Unit tests and test coverage
py27-scipy    -> Unit tests and test coverage
pypy27        -> Unit tests and test coverage
pypy27-scipy  -> Unit tests and test coverage
py35          -> Unit tests and test coverage
py35-scipy    -> Unit tests and test coverage
py36          -> Unit tests and test coverage
py36-scipy    -> Unit tests and test coverage
py37          -> Unit tests and test coverage
py37-scipy    -> Unit tests and test coverage
py38          -> Unit tests and test coverage
py38-scipy    -> Unit tests and test coverage
py39          -> Unit tests and test coverage
py39-scipy    -> Unit tests and test coverage
py310         -> Unit tests and test coverage
py310-scipy   -> Unit tests and test coverage
py311         -> Unit tests and test coverage
py311-scipy   -> Unit tests and test coverage
pypy38        -> Unit tests and test coverage
pypy38-scipy  -> Unit tests and test coverage
pypy39        -> Unit tests and test coverage
pypy39-scipy  -> Unit tests and test coverage
pypy310       -> Unit tests and test coverage
pypy310-scipy -> Unit tests and test coverage
package       -> Build package and check metadata (or upload package)
clean         -> Clean up bytecode and build artifacts
```

</details>

Note that older Python versions (2.7, 3.5, 3.6) will [still be able to test with Tox](https://tox.wiki/en/latest/faq.html#testing-end-of-life-python-versions), locally. Since GHA stopped supporting them in their hosted runners the burden is now on the developers, though.

SciPy requires some build prerequisites for PyPy. This is easy to fulfill on (Ubuntu) Linux, not so on the other platforms. We'll skip macOS and Windows for now.

This is a follow-up on #604.