### PR TITLE
add support of scipy.linalg.solve_banded()

### DIFF
--- a/autograd/scipy/linalg.py
+++ b/autograd/scipy/linalg.py
@@ -52,7 +52,7 @@ def grad_solve_banded(argnum, ans, l_and_u, a, b):
         T_a = anp.roll(a[:1, :], shifts[0])
         for rr in range(1, num_rows):
             T_a = anp.vstack([T_a, anp.flipud(anp.roll(a[rr:rr+1, :], shifts[rr]))])
-            T_a = anp.flipud(T_a)
+        T_a = anp.flipud(T_a)
 
         T_l_and_u = anp.flip(l_and_u)
 

--- a/autograd/scipy/linalg.py
+++ b/autograd/scipy/linalg.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from functools import partial
 import scipy.linalg
 
 import autograd.numpy as anp
@@ -34,6 +35,62 @@ defvjp(solve_triangular,
        grad_solve_triangular,
        lambda ans, a, b, trans=0, lower=False, **kwargs:
        lambda g: solve_triangular(a, g, trans=_flip(a, trans), lower=lower))
+
+def grad_solve_banded(argnum, ans, l_and_u, a, b):
+
+    updim = lambda x: x if x.ndim == a.ndim else x[...,None]
+
+    def transpose_banded(l_and_u, a):
+
+        # Compute the transpose of a banded matrix.
+        # The transpose is itself a banded matrix.
+
+        num_rows = a.shape[0]
+
+        shifts = anp.arange(-l_and_u[1], l_and_u[0]+1)
+
+        T_a = anp.roll(a[:1, :], shifts[0])
+        for rr in range(1, num_rows):
+            T_a = anp.vstack([T_a, anp.flipud(anp.roll(a[rr:rr+1, :], shifts[rr]))])
+            T_a = anp.flipud(T_a)
+
+        T_l_and_u = anp.flip(l_and_u)
+
+        return T_l_and_u, T_a
+
+    def banded_dot(l_and_u, uu, vv):
+
+        # Compute tensor product of vectors uu and vv.
+        # Tensor product elements are resticted to the bands specified by l_and_u.
+
+        # TODO: replace the brute-force ravel() by smarter dimension handeling of uu and vv
+
+        # main diagonal
+        banded_uv = anp.ravel(uu)*anp.ravel(vv)
+
+        # stack below the sub-diagonals
+        for rr in range(1, l_and_u[0]+1):
+            banded_uv_rr = anp.hstack([anp.ravel(uu)[rr:]*anp.ravel(vv)[:-rr], anp.zeros(rr)])
+            banded_uv = anp.vstack([banded_uv, banded_uv_rr])
+
+        # stack above the sup-diagonals
+        for rr in range(1, l_and_u[1]+1):
+            banded_uv_rr = anp.hstack([anp.zeros(rr), anp.ravel(uu)[:-rr]*anp.ravel(vv)[rr:]])
+            banded_uv = anp.vstack([banded_uv_rr, banded_uv])
+
+        return(banded_uv)
+
+    T_l_and_u, T_a = transpose_banded(l_and_u, a)
+
+    if argnum == 1:
+        return lambda g: -banded_dot(l_and_u, updim(solve_banded(T_l_and_u, T_a, g)), anp.transpose(updim(ans)))
+    elif argnum == 2:
+        return lambda g: solve_banded(T_l_and_u, T_a, g)
+
+defvjp(solve_banded,
+       partial(grad_solve_banded, 1),
+       partial(grad_solve_banded, 2),
+       argnums=[1, 2])
 
 def _jvp_sqrtm(dA, ans, A, disp=True, blocksize=64):
     assert disp, "sqrtm jvp not implemented for disp=False"

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -10,6 +10,7 @@ except:
     warn('Skipping scipy tests.')
 else:
     import autograd.numpy as np
+    import autograd.numpy.linalg as npla
     import autograd.numpy.random as npr
     import autograd.scipy.signal
     import autograd.scipy.stats as stats
@@ -189,12 +190,12 @@ else:
     def test_jn():        combo_check(special.jn,        [1])([2], R(4)**2 + 1.3)
     def test_yn():        combo_check(special.yn,        [1])([2], R(4)**2 + 1.3)
 
-    def test_psi():       unary_ufunc_check(special.psi,     lims=[0.3, 2.0], test_complex=False)
-    def test_digamma():   unary_ufunc_check(special.digamma, lims=[0.3, 2.0], test_complex=False)
-    def test_gamma():     unary_ufunc_check(special.gamma,   lims=[0.3, 2.0], test_complex=False)
-    def test_gammaln():   unary_ufunc_check(special.gammaln, lims=[0.3, 2.0], test_complex=False)
-    def test_gammasgn():  unary_ufunc_check(special.gammasgn,lims=[0.3, 2.0], test_complex=False)
-    def test_rgamma()  :  unary_ufunc_check(special.rgamma,  lims=[0.3, 2.0], test_complex=False)
+    def test_psi():       unary_ufunc_check(special.psi,      lims=[0.3, 2.0], test_complex=False)
+    def test_digamma():   unary_ufunc_check(special.digamma,  lims=[0.3, 2.0], test_complex=False)
+    def test_gamma():     unary_ufunc_check(special.gamma,    lims=[0.3, 2.0], test_complex=False)
+    def test_gammaln():   unary_ufunc_check(special.gammaln,  lims=[0.3, 2.0], test_complex=False)
+    def test_gammasgn():  unary_ufunc_check(special.gammasgn, lims=[0.3, 2.0], test_complex=False)
+    def test_rgamma():    unary_ufunc_check(special.rgamma,   lims=[0.3, 2.0], test_complex=False)
     def test_multigammaln(): combo_check(special.multigammaln, [0])([U(4., 5.), U(4., 5., (2,3))],
                                         [1, 2, 3])
 
@@ -228,3 +229,4 @@ else:
     def test_sqrtm(): combo_check(spla.sqrtm, modes=['fwd'], order=2)([R(3, 3)])
     def test_sqrtm(): combo_check(symmetrize_matrix_arg(spla.sqrtm, 0), modes=['fwd', 'rev'], order=2)([R(3, 3)])
     def test_solve_sylvester(): combo_check(spla.solve_sylvester, [0, 1, 2], modes=['rev', 'fwd'], order=2)([R(3, 3)], [R(3, 3)], [R(3, 3)])
+    def test_solve_banded(): combo_check(spla.solve_banded, [1, 2], modes=['rev'], order=1)([(1, 1)], [R(3,5)], [R(5)])

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -10,7 +10,6 @@ except:
     warn('Skipping scipy tests.')
 else:
     import autograd.numpy as np
-    import autograd.numpy.linalg as npla
     import autograd.numpy.random as npr
     import autograd.scipy.signal
     import autograd.scipy.stats as stats
@@ -190,12 +189,12 @@ else:
     def test_jn():        combo_check(special.jn,        [1])([2], R(4)**2 + 1.3)
     def test_yn():        combo_check(special.yn,        [1])([2], R(4)**2 + 1.3)
 
-    def test_psi():       unary_ufunc_check(special.psi,      lims=[0.3, 2.0], test_complex=False)
-    def test_digamma():   unary_ufunc_check(special.digamma,  lims=[0.3, 2.0], test_complex=False)
-    def test_gamma():     unary_ufunc_check(special.gamma,    lims=[0.3, 2.0], test_complex=False)
-    def test_gammaln():   unary_ufunc_check(special.gammaln,  lims=[0.3, 2.0], test_complex=False)
-    def test_gammasgn():  unary_ufunc_check(special.gammasgn, lims=[0.3, 2.0], test_complex=False)
-    def test_rgamma():    unary_ufunc_check(special.rgamma,   lims=[0.3, 2.0], test_complex=False)
+    def test_psi():       unary_ufunc_check(special.psi,     lims=[0.3, 2.0], test_complex=False)
+    def test_digamma():   unary_ufunc_check(special.digamma, lims=[0.3, 2.0], test_complex=False)
+    def test_gamma():     unary_ufunc_check(special.gamma,   lims=[0.3, 2.0], test_complex=False)
+    def test_gammaln():   unary_ufunc_check(special.gammaln, lims=[0.3, 2.0], test_complex=False)
+    def test_gammasgn():  unary_ufunc_check(special.gammasgn,lims=[0.3, 2.0], test_complex=False)
+    def test_rgamma()  :  unary_ufunc_check(special.rgamma,  lims=[0.3, 2.0], test_complex=False)
     def test_multigammaln(): combo_check(special.multigammaln, [0])([U(4., 5.), U(4., 5., (2,3))],
                                         [1, 2, 3])
 


### PR DESCRIPTION
Until now, autograd only handles scipy.linalg.solve() and scipy.linalg.solve_triangular().
 
In contrast to scipy.linalg.solve() and scipy.linalg.solve_triangular(); scipy.linalg.solve_banded() can handle VERY large systems of equations.
 
In fact, I think that solve_banded() could interest a lot of autograd users: banded systems are ubiquitous in ODEs, PDEs and signal processing.
 
Furthermore, solve_banded() could be of interest to a wider audience, since sparse matrix solvers are not handled yet by torch.autograd (to the best of my knowledge).
 
In that sense, solve_banded() would be a first step towards handling a specific subset of sparse matrices, namely  banded matrices.

Last but not least, I hope that, at a later stage, someone could then adapt, improve and include my code to torch.autograd and/or jax.