### PR TITLE
Adjust test_wrapped_name_and_docs for Python 3.13

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -352,6 +352,10 @@ def test_grad_and_aux():
 def test_wrapped_name_and_docs():
     def foo(x): pass
     assert grad.__name__ == 'grad'
-    assert grad.__doc__.startswith("\n    Returns a function which")
+    # Python 3.13: Compiler now strip indents from docstrings.
+    # https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes
+    assert grad.__doc__.startswith(tuple(
+        "\n{}Returns a function which".format(indent) for indent in ("    ", "")
+    ))
     assert grad(foo, 1).__name__ == 'grad_of_foo_wrt_argnum_1'
     assert grad(foo, 1).__doc__.startswith("    grad of function foo with")


### PR DESCRIPTION
In Python 3.13, the bytecode compiler now strips indentation from docstrings; see https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes.

Rather than conditionalizing based on the interpreter version, I adjusted the test to match the docstring with or without indentation.

After this PR, all tests pass in `tox -e py313`. I didn’t try `tox -e py313-scipy` since scipy doesn’t yet publish binary wheels for Python 3.13 and it is difficult to build from source.