### PR TITLE
[ci] Remove python 3.7 runners from test workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,17 +23,13 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
-        - pypy-3.7
         - pypy-3.8
         - pypy-3.9
         - pypy-3.10
-        exclude:
-        - { platform: windows-latest, python-version: pypy-3.7 }
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,10 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
-        - pypy-3.8
+        - '3.12'
         - pypy-3.9
         - pypy-3.10
     steps:


### PR DESCRIPTION
This PR removes Python 3.7 from the CI as it reached it's end of life a year ago (and not all runners are still available in Github Actions). Python 3.8 will reached its EOL in three months so I would propose to support it until then.