### PR TITLE
chore: migrate to hatch + use hatchling for the build backend, drop Python 2 support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,4 +30,4 @@ jobs:
       run: |
         python -m pip install tox wheel
     - name: Run ${{ matrix.env }}
-      run: tox -e ${{ matrix.env }}
+      run: python -m tox -e ${{ matrix.env }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,8 +22,8 @@ jobs:
         #- ruff
         - package
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install build tools

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
         - package
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5.1.1
       with:
         python-version: '3.10'
     - name: Install build tools

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install build tools

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5.1.1
       with:
         python-version: '3.10'
     - name: Install build tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,10 @@ jobs:
     - name: Install Python build tools
       run: python -m pip install tox wheel
     - name: Run tests
-      run: tox run -e py
+      run: python -m tox run -e py
     - name: Install Scipy prerequisites for Ubuntu
       if: startsWith(matrix.platform, 'ubuntu')
       run: sudo apt-get install libopenblas-dev
     - name: Run tests with scipy
       if: startsWith(matrix.platform, 'ubuntu') || startsWith(matrix.python-version, 'pypy') != true
-      run: tox run -e py-scipy
+      run: python -m tox run -e py-scipy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
         - pypy-3.9
         - pypy-3.10
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python build tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         - pypy-3.10
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5.1.1
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python build tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
         - '3.12'
         - pypy-3.9
         - pypy-3.10
+        # TODO: bring this back later
+        exclude:
+        - platform: windows-latest
+          python-version: 'pypy-3.10'
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5.1.1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-recursive-include autograd *.c *.h *.pyx
-prune tests

--- a/autograd/builtins.py
+++ b/autograd/builtins.py
@@ -1,4 +1,3 @@
-from six import with_metaclass
 from .util import subvals
 from .extend import (Box, primitive, notrace_primitive, VSpace, vspace,
                      SparseObject, defvjp, defvjp_argnum, defjvp, defjvp_argnum)
@@ -86,24 +85,25 @@ def fwd_grad_make_sequence(argnum, g, ans, seq_type, *args, **kwargs):
 defjvp_argnum(make_sequence, fwd_grad_make_sequence)
 
 
-class TupleMeta(type_):
+class TupleMeta(type(tuple_)):
     def __instancecheck__(self, instance):
         return isinstance(instance, tuple_)
-class tuple(with_metaclass(TupleMeta, tuple_)):
+
+class tuple(tuple_, metaclass=TupleMeta):
     def __new__(cls, xs):
         return make_sequence(tuple_, *xs)
 
 class ListMeta(type_):
     def __instancecheck__(self, instance):
         return isinstance(instance, list_)
-class list(with_metaclass(ListMeta, list_)):
+class list(list_, metaclass=ListMeta):
     def __new__(cls, xs):
-        return make_sequence(list_,  *xs)
+        return make_sequence(list_, *xs)
 
 class DictMeta(type_):
     def __instancecheck__(self, instance):
         return isinstance(instance, dict_)
-class dict(with_metaclass(DictMeta, dict_)):
+class dict(dict_, metaclass=DictMeta):
     def __new__(cls, *args, **kwargs):
         result = dict_(*args, **kwargs)
         if result:

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from six import string_types
 from functools import partial
 import numpy as onp
 from ..util import func
@@ -588,7 +587,7 @@ def grad_einsum(argnum, ans, operands_, kwargs):
     result_meta = anp.metadata(operands_[argnum])
     def vjp(g):
         operands = operands_
-        if isinstance(operands[0], string_types):  # using "ijk" convention.
+        if isinstance(operands[0], str):  # using "ijk" convention.
             in_subs, out_subs, _ = anp.parse_einsum_input(*operands)
             string, operands = operands[0], operands[1:]
 

--- a/autograd/scipy/signal.py
+++ b/autograd/scipy/signal.py
@@ -6,7 +6,7 @@ import numpy as npo # original numpy
 from autograd.extend import primitive, defvjp
 
 from numpy.lib.stride_tricks import as_strided
-from six import iteritems
+
 
 @primitive
 def convolve(A, B, axes=None, dot_axes=[(),()], mode='full'):
@@ -79,8 +79,8 @@ def parse_axes(A_shape, B_shape, conv_axes, dot_axes, mode):
                    'conv'     : tuple(range(i2, i3))}
     conv_shape = (compute_conv_size(A_shape[i], B_shape[j], mode)
                   for i, j in zip(axes['A']['conv'], axes['B']['conv']))
-    shapes = {'A'   : {s : (A_shape[i] for i in ax) for s, ax in iteritems(axes['A'])},
-              'B'   : {s : (B_shape[i] for i in ax) for s, ax in iteritems(axes['B'])}}
+    shapes = {'A': {s: tuple(A_shape[i] for i in ax) for s, ax in axes['A'].items()},
+              'B': {s: tuple(B_shape[i] for i in ax) for s, ax in axes['B'].items()}}
     shapes['out'] = {'ignore_A' : shapes['A']['ignore'],
                      'ignore_B' : shapes['B']['ignore'],
                      'conv'     : conv_shape}

--- a/conda_recipe/conda.yaml
+++ b/conda_recipe/conda.yaml
@@ -14,7 +14,8 @@ source:
 requirements:
   build:
     - python
-    - setuptools
+    - hatch
+    - hatchling
     - future
     - numpy >=1.9
 
@@ -24,7 +25,7 @@ requirements:
     - numpy >=1.9
 
 build:
-  script: python setup.py build && python setup.py install
+  script: pip install . --no-deps
 
 test:
   # Python imports

--- a/examples/data_mnist.py
+++ b/examples/data_mnist.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import sys
-if sys.version < "3":
-    from future.standard_library import install_aliases
-    install_aliases()
 
 import os
 import gzip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools>=44"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "autograd"
 version = "1.6.3"
-description = "Efficiently computes derivatives of numpy code."
+description = "Efficiently computes derivatives of NumPy code."
 readme = "README.md"
 license = {file = "license.txt"}
 authors = [
@@ -16,22 +16,20 @@ authors = [
 ]
 maintainers = [
   {name = "Jamie Townsend", email = "j.h.n.townsend@uva.nl"},
+  {name = "Fabian Joswig", email = "fabian.joswig@uni-muenster.de"},
+  {name = "Agriya Khetarpal", email = "agriyakhetarpal@outlook.com"},
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Information Technology",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
-  "Programming Language :: Python :: 2",
-  "Programming Language :: Python :: 2.7",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.5",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering",
 ]
 keywords = [
   "Automatic differentiation",
@@ -41,14 +39,16 @@ keywords = [
   "optimization",
   "neural networks",
   "Python",
-  "Numpy",
-  "Scipy",
+  "NumPy",
+  "SciPy",
 ]
 dependencies = [
   "numpy>=1.12",
-  "six",
-  "future>=0.15.2; python_version < '3'",
 ]
+# dynamic = ["version"]
+
+[project.urls]
+Source = "https://github.com/HIPS/autograd"
 
 [project.optional-dependencies]
 scipy = [
@@ -69,12 +69,3 @@ extend-exclude = []
 extend-ignore = ["E731"]
 extend-select = ["I", "W"]
 line-length = 109
-
-[tool.setuptools]
-packages=[
-  "autograd",
-  "autograd.numpy",
-  "autograd.scipy",
-  "autograd.scipy.stats",
-  "autograd.misc",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "autograd"
 version = "1.6.3"
+requires-python = ">=3.8"
 description = "Efficiently computes derivatives of NumPy code."
 readme = "README.md"
 license = {file = "license.txt"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = [
   "SciPy",
 ]
 dependencies = [
-  "numpy>=1.12",
+  "numpy<2",
 ]
 # dynamic = ["version"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 # Tox (https://tox.wiki/) - run tests in isolation using virtualenv.
 # Also contains config settings for tools that don't look into pyproject.toml.
 
+# TODO: Migrate to tool.hatch.run or noxfile.py
+
 [tox]
 envlist =
     ruff
@@ -33,10 +35,10 @@ deps = pyclean
 commands = pyclean {posargs:. --debris --erase junit-report.xml --yes}
 
 [testenv:ruff]
-description = Lightening-fast linting for Python
+description = Lightning-fast linting for Python
 skip_install = true
 deps = ruff
-commands = ruff {posargs:.}
+commands = ruff check {posargs:.}  # TODO: Fix style failures
 
 [testenv:package]
 description = Build package and check metadata (or upload package)


### PR DESCRIPTION
## Description

- Stemmed off from #618 – the packaging infrastructure for `autograd` has been migrated to use `hatchling.build` instead of `setuptools.build_meta` as the build backend. Some missing metadata entries have been added in `pyproject.toml`.
- Dependence on the `six` and `future` libraries has been removed, since all of the code is compatible with Python 3.
- Python 2 support has been dropped and the wheels are tagged with `py3` for the Python tag instead of `py2-py3`.
- Lastly, I added some future TODOs so that I can keep track of them sometime soon.

### What issue does this PR close/address?

Closes #606
Closes #513, since we won't need `setuptools`-specific files anymore.

### Caveats (i.e., tasks for future PRs)

- to enable VCS versioning via dynamic = ["version"] and the `hatch-vcs` plugin to derive the version from Git; and
- to use hatch environment commands in place of `tox` through the addition of a `[tool.hatch.run]` table in `pyproject.toml`.

## Additional notes

The `conda.yaml` file doesn't look like it's going to work anyway; I'll modify this in another PR and switch to an `environment.yaml` file if needed, or we can drop it sometime soon: all of our dependencies both for regular usage and development work are available via PyPI.