### PR TITLE
chore: update the release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,59 @@
 name: Publish
 
 on:
-  push:
-    tags:
-    - '*'
+  workflow_dispatch:
+  release:
+    types: [published]
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: '1'
-  PY_COLORS: '1'
+  FORCE_COLOR: '3'
 
 jobs:
-  publish:
+  build:
+    name: Build sdist and wheel
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      name: Checkout repository
+
     - uses: actions/setup-python@v5.1.1
       with:
-        python-version: '3.10'
+        python-version: "3.12"
+
     - name: Install build tools
       run: |
-        python -m pip install build twine wheel
-    - name: Build package
-      run: python -m build
-    - name: Upload to PyPI
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: twine upload dist/*
+        pipx run build --outdir dist
+
+    - name: Upload wheel and sdist artifacts
+      uses: actions/upload-artifact@v4.3.6
+      with:
+        name: artifacts
+        path: ./dist/*
+        if-no-files-found: error
+
+  publish:
+    needs: [build]
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/autograd
+    permissions:
+      id-token: write # mandatory for trusted publishing
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Sanity check artifacts
+        run: ls -la dist/
+
+      - name: Publish sdist and wheel to PyPI
+        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
+        with:
+          repository-url: https://pypi.org/p/autograd
+          packages-dir: dist/


### PR DESCRIPTION
## Description

Stemmed off from https://github.com/HIPS/autograd/pull/618. This updates the release workflow prior to triggering a new v1.7.0 release.

## Changes made

1. Better coloured output: `FORCE_COLOR:` environment variable set to `3`
2. Workflow will now not be triggered from a tag but from a GitHub Release made from said tag (gives better control in case a tag is created and pushed to GitHub in haste)
3. Uses `pypa/build` to build the sdist and then the wheel from the sdist
4. Some bumps to GitHub Actions versions
5. The build and upload steps are now isolated, sharing artifacts. They are integrated with varying permissions to enhance security in the advent of events from malicious actors. The PyPI upload step uses the environment set in the repository settings and trusted publishing has been set up by @j-towns on the PyPI portal. The PyPI upload action runs twine internally with the strict option to check the sdist and wheel. It is pinned to the commit hash for the latest release at the time of writing (v1.9.0).