### PR TITLE
[Fix] Fix numpy.core.einsumfunc deprecation

### DIFF
--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -5,7 +5,7 @@ from autograd.extend import primitive, notrace_primitive
 import numpy as _np
 import autograd.builtins as builtins
 
-if np_.lib.NumpyVersion(np_.__version__) >= '2.0.0':
+if _np.lib.NumpyVersion(_np.__version__) >= '2.0.0':
     from numpy._core.einsumfunc import _parse_einsum_input
 else:
     from numpy.core.einsumfunc import _parse_einsum_input

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -4,7 +4,11 @@ import warnings
 from autograd.extend import primitive, notrace_primitive
 import numpy as _np
 import autograd.builtins as builtins
-from numpy._core.einsumfunc import _parse_einsum_input
+
+if np_.lib.NumpyVersion(np_.__version__) >= '2.0.0':
+    from numpy._core.einsumfunc import _parse_einsum_input
+else:
+    from numpy.core.einsumfunc import _parse_einsum_input
 
 notrace_functions = [
     _np.ndim, _np.shape, _np.iscomplexobj, _np.result_type

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -4,7 +4,7 @@ import warnings
 from autograd.extend import primitive, notrace_primitive
 import numpy as _np
 import autograd.builtins as builtins
-from numpy.core.einsumfunc import _parse_einsum_input
+from numpy._core.einsumfunc import _parse_einsum_input
 
 notrace_functions = [
     _np.ndim, _np.shape, _np.iscomplexobj, _np.result_type


### PR DESCRIPTION
After the 1.7.0 release I noticed the following deprecation warning:
```
autograd/numpy/numpy_wrapper.py:7: DeprecationWarning: numpy.core.einsumfunc is deprecated and has been renamed to numpy._core.einsumfunc. The numpy._core namespace contains private NumPy internals and its use is discouraged, as NumPy internals can change without warning in any release. In practice, most real-world usage of numpy.core is to access functionality in the public NumPy API. If that is the case, use the public NumPy API. If not, you are using NumPy internals. If you would still like to access an internal attribute, use numpy._core.einsumfunc._parse_einsum_input.
```

This PR simply replaces the import from `numpy.core.einsumfunc` by `numpy._core.einsumfunc` which should fix the warning but adds the risk that `_parse_einsum_input` might break in a furture numpy release without prior warning.