### PR TITLE
[ci] Run test workflow at the beginning of every month and enable manual trigger of the pipeline.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
     - master
   workflow_dispatch:
   schedule:
-    - cron: '0 4 1 * *'
+    - cron: '0 4 * * *'
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: '1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 1 * *'
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: '1'


### PR DESCRIPTION
At least for now I think it can be useful to trigger the test pipeline automatically once every month to spot any problems. I also propose to add `workflow_dispatch` which allows us to manually trigger a run via the GitHub UI without having to push a commit.