### PR TITLE
chore: add pre-commit configuration file, run `ruff-isort`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+ci:
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-yaml
+        exclude: conda_recipe/conda.yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.6.2"
+    hooks:
+      - id: ruff
+        args: ["--fix", "--show-fixes"]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: python-check-blanket-type-ignore
+        exclude: ^src/vector/backends/_numba_object.py$
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal

--- a/autograd/__init__.py
+++ b/autograd/__init__.py
@@ -1,23 +1,24 @@
+from autograd.core import primitive_with_deprecation_warnings as primitive
+
+from .builtins import dict, isinstance, list, tuple, type
 from .differential_operators import (
-    make_vjp,
-    grad,
-    multigrad_dict,
+    checkpoint,
+    deriv,
     elementwise_grad,
-    value_and_grad,
+    grad,
     grad_and_aux,
+    grad_named,
+    hessian,
     hessian_tensor_product,
     hessian_vector_product,
-    hessian,
+    holomorphic_grad,
     jacobian,
-    tensor_jacobian_product,
-    vector_jacobian_product,
-    grad_named,
-    checkpoint,
+    make_ggnvp,
     make_hvp,
     make_jvp,
-    make_ggnvp,
-    deriv,
-    holomorphic_grad,
+    make_vjp,
+    multigrad_dict,
+    tensor_jacobian_product,
+    value_and_grad,
+    vector_jacobian_product,
 )
-from .builtins import isinstance, type, tuple, list, dict
-from autograd.core import primitive_with_deprecation_warnings as primitive

--- a/autograd/builtins.py
+++ b/autograd/builtins.py
@@ -1,16 +1,16 @@
-from .util import subvals
 from .extend import (
     Box,
-    primitive,
-    notrace_primitive,
-    VSpace,
-    vspace,
     SparseObject,
-    defvjp,
-    defvjp_argnum,
+    VSpace,
     defjvp,
     defjvp_argnum,
+    defvjp,
+    defvjp_argnum,
+    notrace_primitive,
+    primitive,
+    vspace,
 )
+from .util import subvals
 
 isinstance_ = isinstance
 isinstance = notrace_primitive(isinstance)

--- a/autograd/core.py
+++ b/autograd/core.py
@@ -1,6 +1,7 @@
-from itertools import count
 from functools import reduce
-from .tracer import trace, primitive, toposort, Node, Box, isbox, getval
+from itertools import count
+
+from .tracer import Box, Node, getval, isbox, primitive, toposort, trace
 from .util import func, subval
 
 # -------------------- reverse mode --------------------
@@ -40,9 +41,7 @@ class VJPNode(Node):
             vjpmaker = primitive_vjps[fun]
         except KeyError:
             fun_name = getattr(fun, "__name__", fun)
-            raise NotImplementedError(
-                f"VJP of {fun_name} wrt argnums {parent_argnums} not defined"
-            )
+            raise NotImplementedError(f"VJP of {fun_name} wrt argnums {parent_argnums} not defined")
         self.vjp = vjpmaker(parent_argnums, value, args, kwargs)
 
     def initialize_root(self):

--- a/autograd/differential_operators.py
+++ b/autograd/differential_operators.py
@@ -1,6 +1,5 @@
 """Convenience functions built on top of `make_vjp`."""
 
-from functools import partial
 from collections import OrderedDict
 
 try:
@@ -9,12 +8,13 @@ except ImportError:
     from inspect import getargspec as _getargspec  # Python 2
 import warnings
 
-from .wrap_util import unary_to_nary
-from .builtins import tuple as atuple
-from .core import make_vjp as _make_vjp, make_jvp as _make_jvp
-from .extend import primitive, defvjp_argnum, vspace
-
 import autograd.numpy as np
+
+from .builtins import tuple as atuple
+from .core import make_jvp as _make_jvp
+from .core import make_vjp as _make_vjp
+from .extend import defvjp_argnum, primitive, vspace
+from .wrap_util import unary_to_nary
 
 make_vjp = unary_to_nary(_make_vjp)
 make_jvp = unary_to_nary(_make_jvp)

--- a/autograd/extend.py
+++ b/autograd/extend.py
@@ -1,16 +1,16 @@
 # Exposes API for extending autograd
-from .tracer import Box, primitive, register_notrace, notrace_primitive
 from .core import (
-    SparseObject,
-    VSpace,
-    vspace,
-    VJPNode,
     JVPNode,
-    defvjp_argnums,
-    defvjp_argnum,
-    defvjp,
-    defjvp_argnums,
-    defjvp_argnum,
-    defjvp,
+    SparseObject,
+    VJPNode,
+    VSpace,
     def_linear,
+    defjvp,
+    defjvp_argnum,
+    defjvp_argnums,
+    defvjp,
+    defvjp_argnum,
+    defvjp_argnums,
+    vspace,
 )
+from .tracer import Box, notrace_primitive, primitive, register_notrace

--- a/autograd/misc/__init__.py
+++ b/autograd/misc/__init__.py
@@ -1,2 +1,2 @@
-from .tracers import const_graph
 from .flatten import flatten
+from .tracers import const_graph

--- a/autograd/misc/fixed_points.py
+++ b/autograd/misc/fixed_points.py
@@ -1,6 +1,6 @@
-from autograd.extend import primitive, defvjp, vspace
-from autograd.builtins import tuple
 from autograd import make_vjp
+from autograd.builtins import tuple
+from autograd.extend import defvjp, primitive, vspace
 
 
 @primitive

--- a/autograd/misc/flatten.py
+++ b/autograd/misc/flatten.py
@@ -3,9 +3,9 @@ Handy functions for flattening nested containers containing numpy
 arrays. The main purpose is to make examples and optimizers simpler.
 """
 
+import autograd.numpy as np
 from autograd import make_vjp
 from autograd.builtins import type
-import autograd.numpy as np
 
 
 def flatten(value):

--- a/autograd/misc/optimizers.py
+++ b/autograd/misc/optimizers.py
@@ -7,7 +7,6 @@ to do meta-optimization.
 These routines can optimize functions whose inputs are structured
 objects, such as dicts of numpy arrays."""
 
-
 import autograd.numpy as np
 from autograd.misc import flatten
 from autograd.wrap_util import wraps

--- a/autograd/misc/tracers.py
+++ b/autograd/misc/tracers.py
@@ -1,8 +1,9 @@
-from itertools import repeat
-from autograd.wrap_util import wraps
-from autograd.util import subvals, toposort
-from autograd.tracer import trace, Node
 from functools import partial
+from itertools import repeat
+
+from autograd.tracer import Node, trace
+from autograd.util import subvals, toposort
+from autograd.wrap_util import wraps
 
 
 class ConstGraphNode(Node):

--- a/autograd/numpy/__init__.py
+++ b/autograd/numpy/__init__.py
@@ -1,8 +1,2 @@
+from . import fft, linalg, numpy_boxes, numpy_jvps, numpy_vjps, numpy_vspaces, random
 from .numpy_wrapper import *
-from . import numpy_boxes
-from . import numpy_vspaces
-from . import numpy_vjps
-from . import numpy_jvps
-from . import linalg
-from . import fft
-from . import random

--- a/autograd/numpy/fft.py
+++ b/autograd/numpy/fft.py
@@ -1,8 +1,10 @@
 import numpy.fft as ffto
-from .numpy_wrapper import wrap_namespace
-from .numpy_vjps import match_complex
+
+from autograd.extend import defvjp, primitive, vspace
+
 from . import numpy_wrapper as anp
-from autograd.extend import primitive, defvjp, vspace
+from .numpy_vjps import match_complex
+from .numpy_wrapper import wrap_namespace
 
 wrap_namespace(ffto.__dict__, globals())
 

--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -1,8 +1,11 @@
 from functools import partial
+
 import numpy.linalg as npla
-from .numpy_wrapper import wrap_namespace
+
+from autograd.extend import defjvp, defvjp
+
 from . import numpy_wrapper as anp
-from autograd.extend import defvjp, defjvp
+from .numpy_wrapper import wrap_namespace
 
 wrap_namespace(npla.__dict__, globals())
 

--- a/autograd/numpy/numpy_boxes.py
+++ b/autograd/numpy/numpy_boxes.py
@@ -1,6 +1,8 @@
 import numpy as np
-from autograd.extend import Box, primitive
+
 from autograd.builtins import SequenceBox
+from autograd.extend import Box, primitive
+
 from . import numpy_wrapper as anp
 
 Box.__array_priority__ = 90.0

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -1,19 +1,21 @@
 import numpy as onp
+
+from autograd.extend import JVPNode, def_linear, defjvp, defjvp_argnum, register_notrace, vspace
+
+from ..util import func
 from . import numpy_wrapper as anp
+from .numpy_boxes import ArrayBox
 from .numpy_vjps import (
-    untake,
     balanced_eq,
-    match_complex,
-    replace_zero,
     dot_adjoint_0,
     dot_adjoint_1,
+    match_complex,
+    nograd_functions,
+    replace_zero,
     tensordot_adjoint_0,
     tensordot_adjoint_1,
-    nograd_functions,
+    untake,
 )
-from autograd.extend import defjvp, defjvp_argnum, def_linear, vspace, JVPNode, register_notrace
-from ..util import func
-from .numpy_boxes import ArrayBox
 
 for fun in nograd_functions:
     register_notrace(JVPNode, fun)

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -1,9 +1,12 @@
 from functools import partial
+
 import numpy as onp
+
+from autograd.extend import SparseObject, VJPNode, defvjp, defvjp_argnum, primitive, register_notrace, vspace
+
 from ..util import func
 from . import numpy_wrapper as anp
 from .numpy_boxes import ArrayBox
-from autograd.extend import primitive, vspace, defvjp, defvjp_argnum, SparseObject, VJPNode, register_notrace
 
 # ----- Non-differentiable functions -----
 

--- a/autograd/numpy/numpy_vspaces.py
+++ b/autograd/numpy/numpy_vspaces.py
@@ -1,6 +1,7 @@
 import numpy as np
-from autograd.extend import VSpace
+
 from autograd.builtins import NamedTupleVSpace
+from autograd.extend import VSpace
 
 
 class ArrayVSpace(VSpace):

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -1,8 +1,9 @@
-import types
 import warnings
-from autograd.extend import primitive, notrace_primitive
+
 import numpy as _np
+
 import autograd.builtins as builtins
+from autograd.extend import notrace_primitive, primitive
 
 if _np.lib.NumpyVersion(_np.__version__) >= "2.0.0":
     from numpy._core.einsumfunc import _parse_einsum_input
@@ -75,9 +76,7 @@ def array(A, *args, **kwargs):
 def wrap_if_boxes_inside(raw_array, slow_op_name=None):
     if raw_array.dtype is _np.dtype("O"):
         if slow_op_name:
-            warnings.warn(
-                "{} is slow for array inputs. " "np.concatenate() is faster.".format(slow_op_name)
-            )
+            warnings.warn("{} is slow for array inputs. " "np.concatenate() is faster.".format(slow_op_name))
         return array_from_args((), {}, *raw_array.ravel()).reshape(raw_array.shape)
     else:
         return raw_array

--- a/autograd/numpy/random.py
+++ b/autograd/numpy/random.py
@@ -1,4 +1,5 @@
 import numpy.random as npr
+
 from .numpy_wrapper import wrap_namespace
 
 wrap_namespace(npr.__dict__, globals())

--- a/autograd/scipy/__init__.py
+++ b/autograd/scipy/__init__.py
@@ -1,7 +1,4 @@
-from . import integrate
-from . import signal
-from . import special
-from . import stats
+from . import integrate, signal, special, stats
 
 try:
     from . import misc

--- a/autograd/scipy/integrate.py
+++ b/autograd/scipy/integrate.py
@@ -1,10 +1,10 @@
 import scipy.integrate
 
 import autograd.numpy as np
-from autograd.extend import primitive, defvjp_argnums
 from autograd import make_vjp
-from autograd.misc import flatten
 from autograd.builtins import tuple
+from autograd.extend import defvjp_argnums, primitive
+from autograd.misc import flatten
 
 odeint = primitive(scipy.integrate.odeint)
 

--- a/autograd/scipy/linalg.py
+++ b/autograd/scipy/linalg.py
@@ -1,9 +1,10 @@
 from functools import partial
+
 import scipy.linalg
 
 import autograd.numpy as anp
+from autograd.extend import defjvp, defjvp_argnums, defvjp, defvjp_argnums
 from autograd.numpy.numpy_wrapper import wrap_namespace
-from autograd.extend import defvjp, defvjp_argnums, defjvp, defjvp_argnums
 
 wrap_namespace(scipy.linalg.__dict__, globals())  # populates module namespace
 

--- a/autograd/scipy/misc.py
+++ b/autograd/scipy/misc.py
@@ -1,4 +1,5 @@
 import scipy.misc as osp_misc
+
 from ..scipy import special
 
 if hasattr(osp_misc, "logsumexp"):

--- a/autograd/scipy/signal.py
+++ b/autograd/scipy/signal.py
@@ -1,9 +1,10 @@
 from functools import partial
-import autograd.numpy as np
-import numpy as npo  # original numpy
-from autograd.extend import primitive, defvjp
 
+import numpy as npo  # original numpy
 from numpy.lib.stride_tricks import as_strided
+
+import autograd.numpy as np
+from autograd.extend import defvjp, primitive
 
 
 @primitive

--- a/autograd/scipy/special.py
+++ b/autograd/scipy/special.py
@@ -1,7 +1,8 @@
 import scipy.special
+
 import autograd.numpy as np
-from autograd.extend import primitive, defvjp, defjvp
-from autograd.numpy.numpy_vjps import unbroadcast_f, repeat_to_match_shape
+from autograd.extend import defjvp, defvjp, primitive
+from autograd.numpy.numpy_vjps import repeat_to_match_shape, unbroadcast_f
 
 ### Beta function ###
 beta = primitive(scipy.special.beta)

--- a/autograd/scipy/stats/__init__.py
+++ b/autograd/scipy/stats/__init__.py
@@ -1,9 +1,4 @@
-from . import chi2
-from . import beta
-from . import gamma
-from . import norm
-from . import poisson
-from . import t
+from . import beta, chi2, gamma, norm, poisson, t
 
 # Try block needed in case the user has an
 # old version of scipy without multivariate normal.

--- a/autograd/scipy/stats/beta.py
+++ b/autograd/scipy/stats/beta.py
@@ -1,6 +1,7 @@
-import autograd.numpy as np
 import scipy.stats
-from autograd.extend import primitive, defvjp
+
+import autograd.numpy as np
+from autograd.extend import defvjp, primitive
 from autograd.numpy.numpy_vjps import unbroadcast_f
 from autograd.scipy.special import beta, psi
 

--- a/autograd/scipy/stats/chi2.py
+++ b/autograd/scipy/stats/chi2.py
@@ -1,6 +1,7 @@
-import autograd.numpy as np
 import scipy.stats
-from autograd.extend import primitive, defvjp
+
+import autograd.numpy as np
+from autograd.extend import defvjp, primitive
 from autograd.numpy.numpy_vjps import unbroadcast_f
 from autograd.scipy.special import gamma
 

--- a/autograd/scipy/stats/dirichlet.py
+++ b/autograd/scipy/stats/dirichlet.py
@@ -1,8 +1,8 @@
 import scipy.stats
 
 import autograd.numpy as np
+from autograd.extend import defvjp, primitive
 from autograd.scipy.special import digamma
-from autograd.extend import primitive, defvjp
 
 rvs = primitive(scipy.stats.dirichlet.rvs)
 pdf = primitive(scipy.stats.dirichlet.pdf)

--- a/autograd/scipy/stats/gamma.py
+++ b/autograd/scipy/stats/gamma.py
@@ -1,6 +1,7 @@
-import autograd.numpy as np
 import scipy.stats
-from autograd.extend import primitive, defvjp
+
+import autograd.numpy as np
+from autograd.extend import defvjp, primitive
 from autograd.numpy.numpy_vjps import unbroadcast_f
 from autograd.scipy.special import gamma, psi
 

--- a/autograd/scipy/stats/multivariate_normal.py
+++ b/autograd/scipy/stats/multivariate_normal.py
@@ -1,9 +1,8 @@
 import scipy.stats
 
 import autograd.numpy as np
+from autograd.extend import defvjp, primitive
 from autograd.numpy.numpy_vjps import unbroadcast_f
-from autograd.extend import primitive, defvjp
-
 
 pdf = primitive(scipy.stats.multivariate_normal.pdf)
 logpdf = primitive(scipy.stats.multivariate_normal.logpdf)

--- a/autograd/scipy/stats/norm.py
+++ b/autograd/scipy/stats/norm.py
@@ -1,8 +1,9 @@
 """Gradients of the normal distribution."""
 
 import scipy.stats
+
 import autograd.numpy as anp
-from autograd.extend import primitive, defvjp
+from autograd.extend import defvjp, primitive
 from autograd.numpy.numpy_vjps import unbroadcast_f
 
 pdf = primitive(scipy.stats.norm.pdf)

--- a/autograd/scipy/stats/poisson.py
+++ b/autograd/scipy/stats/poisson.py
@@ -1,6 +1,7 @@
-import autograd.numpy as np
 import scipy.stats
-from autograd.extend import primitive, defvjp
+
+import autograd.numpy as np
+from autograd.extend import defvjp, primitive
 from autograd.numpy.numpy_vjps import unbroadcast_f
 
 cdf = primitive(scipy.stats.poisson.cdf)

--- a/autograd/scipy/stats/t.py
+++ b/autograd/scipy/stats/t.py
@@ -1,8 +1,9 @@
 """Gradients of the univariate t distribution."""
 
 import scipy.stats
+
 import autograd.numpy as np
-from autograd.extend import primitive, defvjp
+from autograd.extend import defvjp, primitive
 from autograd.numpy.numpy_vjps import unbroadcast_f
 from autograd.scipy.special import psi
 

--- a/autograd/test_util.py
+++ b/autograd/test_util.py
@@ -1,8 +1,7 @@
-from functools import partial
 from itertools import product
-from .core import make_vjp, make_jvp, vspace
-from .util import subvals
-from .wrap_util import unary_to_nary, get_name
+
+from .core import make_jvp, make_vjp, vspace
+from .wrap_util import get_name, unary_to_nary
 
 TOL = 1e-6
 RTOL = 1e-6
@@ -57,9 +56,7 @@ def check_equivalent(x, y):
     x_vs, y_vs = vspace(x), vspace(y)
     assert x_vs == y_vs, f"VSpace mismatch:\nx: {x_vs}\ny: {y_vs}"
     v = x_vs.randn()
-    assert scalar_close(
-        x_vs.inner_prod(x, v), x_vs.inner_prod(y, v)
-    ), f"Value mismatch:\nx: {x}\ny: {y}"
+    assert scalar_close(x_vs.inner_prod(x, v), x_vs.inner_prod(y, v)), f"Value mismatch:\nx: {x}\ny: {y}"
 
 
 @unary_to_nary

--- a/autograd/tracer.py
+++ b/autograd/tracer.py
@@ -1,6 +1,7 @@
 import warnings
-from contextlib import contextmanager
 from collections import defaultdict
+from contextlib import contextmanager
+
 from .util import subvals, toposort
 from .wrap_util import wraps
 

--- a/autograd/util.py
+++ b/autograd/util.py
@@ -1,5 +1,4 @@
 import operator
-import sys
 
 
 def subvals(x, ivs):
@@ -13,7 +12,6 @@ def subval(x, i, v):
     x_ = list(x)
     x_[i] = v
     return tuple(x_)
-
 
 
 def func(f):

--- a/benchmarks/bench_core.py
+++ b/benchmarks/bench_core.py
@@ -1,14 +1,15 @@
 import numpy as onp
+
 import autograd.numpy as np
 from autograd import grad
 
 try:
-    from autograd.core import vspace, VJPNode, backward_pass
-    from autograd.tracer import trace, new_box
+    from autograd.core import VJPNode, backward_pass, vspace
+    from autograd.tracer import new_box, trace
 
     MASTER_BRANCH = False
 except ImportError:
-    from autograd.core import vspace, forward_pass, backward_pass, new_progenitor
+    from autograd.core import backward_pass, forward_pass, new_progenitor, vspace
 
     MASTER_BRANCH = True
 

--- a/benchmarks/bench_numpy_vjps.py
+++ b/benchmarks/bench_numpy_vjps.py
@@ -1,7 +1,6 @@
-from autograd import make_vjp
-
 import autograd.numpy as np
 import autograd.numpy.random as npr
+from autograd import make_vjp
 
 dot_0 = lambda a, b, g: make_vjp(np.dot, argnum=0)(a, b)[0](g)
 dot_1 = lambda a, b, g: make_vjp(np.dot, argnum=1)(a, b)[0](g)

--- a/benchmarks/bench_rnn.py
+++ b/benchmarks/bench_rnn.py
@@ -1,8 +1,8 @@
 # Write the benchmarking functions here.
 # See "Writing benchmarks" in the asv docs for more information.
 # http://asv.readthedocs.io/en/latest/writing_benchmarks.html
-from autograd import grad
 import autograd.numpy as np
+from autograd import grad
 
 
 class RNNSuite:

--- a/benchmarks/bench_util.py
+++ b/benchmarks/bench_util.py
@@ -1,5 +1,5 @@
-import autograd.numpy.random as npr
 import autograd.numpy as np
+import autograd.numpy.random as npr
 from autograd import grad
 
 try:

--- a/examples/bayesian_neural_net.py
+++ b/examples/bayesian_neural_net.py
@@ -1,9 +1,8 @@
 import matplotlib.pyplot as plt
+from black_box_svi import black_box_variational_inference
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
-
-from black_box_svi import black_box_variational_inference
 from autograd.misc.optimizers import adam
 
 

--- a/examples/bayesian_optimization.py
+++ b/examples/bayesian_optimization.py
@@ -2,12 +2,12 @@
 to find the next query point."""
 
 import matplotlib.pyplot as plt
+from gaussian_process import make_gp_funs, rbf_covariance
+from scipy.optimize import minimize
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import value_and_grad
-from scipy.optimize import minimize
-from gaussian_process import make_gp_funs, rbf_covariance
 from autograd.scipy.stats import norm
 
 

--- a/examples/black_box_svi.py
+++ b/examples/black_box_svi.py
@@ -4,7 +4,6 @@ import autograd.numpy as np
 import autograd.numpy.random as npr
 import autograd.scipy.stats.multivariate_normal as mvn
 import autograd.scipy.stats.norm as norm
-
 from autograd import grad
 from autograd.misc.optimizers import adam
 

--- a/examples/convnet.py
+++ b/examples/convnet.py
@@ -1,12 +1,12 @@
 """Convolutional neural net on MNIST, modeled on 'LeNet-5',
 http://yann.lecun.com/exdb/publis/pdf/lecun-98.pdf"""
 
+import data_mnist
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
 import autograd.scipy.signal
 from autograd import grad
-import data_mnist
 
 convolve = autograd.scipy.signal.convolve
 

--- a/examples/data.py
+++ b/examples/data.py
@@ -1,9 +1,9 @@
-import matplotlib.pyplot as plt
+import data_mnist
 import matplotlib.image
+import matplotlib.pyplot as plt
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
-import data_mnist
 
 
 def load_mnist():

--- a/examples/data_mnist.py
+++ b/examples/data_mnist.py
@@ -1,11 +1,10 @@
-import sys
-
-import os
-import gzip
-import struct
 import array
-import numpy as np
+import gzip
+import os
+import struct
 from urllib.request import urlretrieve
+
+import numpy as np
 
 
 def download(url, filename):

--- a/examples/deep_gaussian_process.py
+++ b/examples/deep_gaussian_process.py
@@ -1,11 +1,10 @@
 import matplotlib.pyplot as plt
+from gaussian_process import make_gp_funs, rbf_covariance
+from scipy.optimize import minimize
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import value_and_grad
-from scipy.optimize import minimize
-
-from gaussian_process import make_gp_funs, rbf_covariance
 
 
 def build_step_function_dataset(D=1, n_data=40, noise_std=0.1):

--- a/examples/define_gradient.py
+++ b/examples/define_gradient.py
@@ -4,9 +4,8 @@ your code depends on external library calls."""
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
-
 from autograd import grad
-from autograd.extend import primitive, defvjp
+from autograd.extend import defvjp, primitive
 from autograd.test_util import check_grads
 
 

--- a/examples/dot_graph.py
+++ b/examples/dot_graph.py
@@ -5,8 +5,7 @@ python2 dot_graph.py | dot -Tpdf -o graph.pdf
 """
 
 import autograd.numpy as np
-from autograd.tracer import trace, Node
-from autograd import grad
+from autograd.tracer import Node, trace
 
 
 class GraphNode(Node):

--- a/examples/fluidsim/fluidsim.py
+++ b/examples/fluidsim/fluidsim.py
@@ -1,12 +1,12 @@
-import autograd.numpy as np
-from autograd import value_and_grad
-
-from scipy.optimize import minimize
-from scipy.misc import imread
+import os
 
 import matplotlib
 import matplotlib.pyplot as plt
-import os
+from scipy.misc import imread
+from scipy.optimize import minimize
+
+import autograd.numpy as np
+from autograd import value_and_grad
 
 # Fluid simulation code based on
 # "Real-Time Fluid Dynamics for Games" by Jos Stam

--- a/examples/fluidsim/wing.py
+++ b/examples/fluidsim/wing.py
@@ -1,10 +1,10 @@
-import autograd.numpy as np
-from autograd import value_and_grad
-
-from scipy.optimize import minimize
+import os
 
 import matplotlib.pyplot as plt
-import os
+from scipy.optimize import minimize
+
+import autograd.numpy as np
+from autograd import value_and_grad
 
 rows, cols = 40, 60
 

--- a/examples/gaussian_process.py
+++ b/examples/gaussian_process.py
@@ -1,11 +1,11 @@
 import matplotlib.pyplot as plt
+from scipy.optimize import minimize
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.numpy.linalg import solve
 import autograd.scipy.stats.multivariate_normal as mvn
 from autograd import value_and_grad
-from scipy.optimize import minimize
+from autograd.numpy.linalg import solve
 
 
 def make_gp_funs(cov_func, num_cov_params):

--- a/examples/generative_adversarial_net.py
+++ b/examples/generative_adversarial_net.py
@@ -3,13 +3,12 @@
 # but, it always collapses to generating a single image.
 # Let me know if you can get it to work! - David Duvenaud
 
+from data import load_mnist, save_images
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import grad
 from autograd.misc import flatten
-
-from data import load_mnist, save_images
-
 
 ### Define geneerator, discriminator, and objective ###
 

--- a/examples/gmm.py
+++ b/examples/gmm.py
@@ -3,15 +3,15 @@ gradient descent.  This example runs on 2-dimensional data, but the model
 works on arbitrarily-high dimension."""
 
 import matplotlib.pyplot as plt
+from data import make_pinwheel
+from scipy.optimize import minimize
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd import grad, hessian_vector_product
-from scipy.optimize import minimize
-from autograd.scipy.special import logsumexp
 import autograd.scipy.stats.multivariate_normal as mvn
+from autograd import grad, hessian_vector_product
 from autograd.misc.flatten import flatten_func
-from data import make_pinwheel
+from autograd.scipy.special import logsumexp
 
 
 def init_gmm_params(num_components, D, scale, rs=npr.RandomState(0)):

--- a/examples/gplvm.py
+++ b/examples/gplvm.py
@@ -12,15 +12,14 @@
 
 
 import matplotlib.pyplot as plt
+from data import make_pinwheel
+from gaussian_process import make_gp_funs, rbf_covariance
+from scipy.optimize import minimize
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import value_and_grad
-from scipy.optimize import minimize
 from autograd.scipy.stats import norm
-
-from gaussian_process import make_gp_funs, rbf_covariance
-from data import make_pinwheel
 
 if __name__ == "__main__":
     data_dimension = 2  # Normally the data dimension would be much higher.

--- a/examples/hmm_em.py
+++ b/examples/hmm_em.py
@@ -1,10 +1,11 @@
+import string
+from functools import partial
+from os.path import dirname, join
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.scipy.special import logsumexp
 from autograd import value_and_grad as vgrad
-from functools import partial
-from os.path import join, dirname
-import string
+from autograd.scipy.special import logsumexp
 
 
 def EM(init_params, data, callback=None):

--- a/examples/ica.py
+++ b/examples/ica.py
@@ -1,12 +1,11 @@
-import matplotlib.pyplot as plt
 import matplotlib.cm as cm
+import matplotlib.pyplot as plt
+from scipy.optimize import minimize
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
 import autograd.scipy.stats.t as t
 from autograd import value_and_grad
-
-from scipy.optimize import minimize
 
 
 def make_ica_funs(observed_dimension, latent_dimension):

--- a/examples/lstm.py
+++ b/examples/lstm.py
@@ -3,13 +3,14 @@ This version vectorizes over multiple examples, but each string
 has a fixed length."""
 
 from os.path import dirname, join
+
+from rnn import build_dataset, concat_and_multiply, one_hot_to_string, sigmoid, string_to_one_hot
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import grad
-from autograd.scipy.special import logsumexp
-
 from autograd.misc.optimizers import adam
-from rnn import string_to_one_hot, one_hot_to_string, build_dataset, sigmoid, concat_and_multiply
+from autograd.scipy.special import logsumexp
 
 
 def init_lstm_params(input_size, state_size, output_size, param_scale=0.01, rs=npr.RandomState(0)):

--- a/examples/mixture_variational_inference.py
+++ b/examples/mixture_variational_inference.py
@@ -9,10 +9,9 @@ import matplotlib.pyplot as plt
 import autograd.numpy as np
 import autograd.numpy.random as npr
 import autograd.scipy.stats.norm as norm
-from autograd.scipy.special import logsumexp
-
 from autograd import grad
 from autograd.misc.optimizers import adam
+from autograd.scipy.special import logsumexp
 
 
 def diag_gaussian_log_density(x, mu, log_std):

--- a/examples/natural_gradient_black_box_svi.py
+++ b/examples/natural_gradient_black_box_svi.py
@@ -1,12 +1,11 @@
 import matplotlib.pyplot as plt
 
-import autograd.numpy as np
-import autograd.scipy.stats.norm as norm
-
-from autograd.misc.optimizers import adam, sgd
-
 # same BBSVI function!
 from black_box_svi import black_box_variational_inference
+
+import autograd.numpy as np
+import autograd.scipy.stats.norm as norm
+from autograd.misc.optimizers import adam, sgd
 
 if __name__ == "__main__":
     # Specify an inference problem by its unnormalized log-density.

--- a/examples/negative_binomial_maxlike.py
+++ b/examples/negative_binomial_maxlike.py
@@ -1,10 +1,9 @@
-import autograd.numpy as np
-import autograd.numpy.random as npr
-from autograd.scipy.special import gammaln
-from autograd import grad
-
 import scipy.optimize
 
+import autograd.numpy as np
+import autograd.numpy.random as npr
+from autograd import grad
+from autograd.scipy.special import gammaln
 
 # The code in this example implements a method for finding a stationary point of
 # the negative binomial likelihood via Newton's method, described here:

--- a/examples/neural_net.py
+++ b/examples/neural_net.py
@@ -1,12 +1,13 @@
 """A multi-layer perceptron for classification of MNIST handwritten digits."""
 
+from data import load_mnist
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.scipy.special import logsumexp
 from autograd import grad
 from autograd.misc.flatten import flatten
 from autograd.misc.optimizers import adam
-from data import load_mnist
+from autograd.scipy.special import logsumexp
 
 
 def init_random_params(scale, layer_sizes, rs=npr.RandomState(0)):

--- a/examples/neural_net_regression.py
+++ b/examples/neural_net_regression.py
@@ -5,7 +5,6 @@ import autograd.numpy.random as npr
 import autograd.scipy.stats.norm as norm
 from autograd import grad
 from autograd.misc import flatten
-
 from autograd.misc.optimizers import adam
 
 

--- a/examples/ode_net.py
+++ b/examples/ode_net.py
@@ -6,12 +6,11 @@ import matplotlib.pyplot as plt
 import numpy as npo
 
 import autograd.numpy as np
+import autograd.numpy.random as npr
 from autograd import grad
-from autograd.scipy.integrate import odeint
 from autograd.builtins import tuple
 from autograd.misc.optimizers import adam
-import autograd.numpy.random as npr
-
+from autograd.scipy.integrate import odeint
 
 N = 30  # Dataset size
 D = 2  # Data dimension

--- a/examples/print_trace.py
+++ b/examples/print_trace.py
@@ -3,7 +3,7 @@ creating a trace that prints out functions and their arguments as they're being
 evaluated"""
 
 import autograd.numpy as np  # autograd has already wrapped numpy for us
-from autograd.tracer import trace, Node
+from autograd.tracer import Node, trace
 
 
 class PrintNode(Node):

--- a/examples/rkhs.py
+++ b/examples/rkhs.py
@@ -5,9 +5,9 @@ gradients of eval with respect to the function-valued argument
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.extend import primitive, defvjp, defjvp, VSpace, Box
-from autograd.util import func
 from autograd import grad
+from autograd.extend import Box, VSpace, defvjp, primitive
+from autograd.util import func
 
 
 class RKHSFun:

--- a/examples/rnn.py
+++ b/examples/rnn.py
@@ -2,13 +2,13 @@
 This version vectorizes over multiple examples, but each string
 has a fixed length."""
 
+from os.path import dirname, join
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import grad
-from autograd.scipy.special import logsumexp
-from os.path import dirname, join
 from autograd.misc.optimizers import adam
-
+from autograd.scipy.special import logsumexp
 
 ### Helper functions #################
 

--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -1,6 +1,7 @@
+from scipy.optimize import minimize
+
 import autograd.numpy as np
 from autograd import value_and_grad
-from scipy.optimize import minimize
 
 
 def rosenbrock(x):

--- a/examples/sinusoid.py
+++ b/examples/sinusoid.py
@@ -1,5 +1,6 @@
-import autograd.numpy as np
 import matplotlib.pyplot as plt
+
+import autograd.numpy as np
 from autograd import grad
 
 

--- a/examples/tanh.py
+++ b/examples/tanh.py
@@ -1,5 +1,6 @@
-import autograd.numpy as np
 import matplotlib.pyplot as plt
+
+import autograd.numpy as np
 from autograd import elementwise_grad as egrad
 
 """

--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -1,13 +1,13 @@
 # Implements auto-encoding variational Bayes.
 
+from data import load_mnist, save_images
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
 import autograd.scipy.stats.norm as norm
-from autograd.scipy.special import expit as sigmoid
-
 from autograd import grad
 from autograd.misc.optimizers import adam
-from data import load_mnist, save_images
+from autograd.scipy.special import expit as sigmoid
 
 
 def diag_gaussian_log_density(x, mu, log_std):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,18 @@ addopts = "--color=yes --junitxml=junit-report.xml"
 
 [tool.ruff]
 extend-exclude = []
-lint.extend-ignore = ["E731"]
+# TODO: not ignore them
+lint.extend-ignore = [
+  "E731",
+  "F401",
+  "F403",
+  "F841",
+  "F821",
+  "E721",
+  "E722",
+  "E741",
+  "E402",
+  "F811"
+]
 lint.extend-select = ["I", "W"]
 line-length = 109

--- a/tests/_test_complexity.py
+++ b/tests/_test_complexity.py
@@ -1,7 +1,8 @@
 import time
 import warnings
-from autograd import grad, deriv
+
 import autograd.numpy as np
+from autograd import deriv, grad
 from autograd.builtins import list as make_list
 
 

--- a/tests/numpy_utils.py
+++ b/tests/numpy_utils.py
@@ -1,8 +1,5 @@
-import itertools as it
 import autograd.numpy.random as npr
-from autograd import grad
 from autograd.test_util import combo_check
-import warnings
 
 
 def stat_check(fun, test_complex=True, **kwargs):

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -1,8 +1,9 @@
-from autograd import grad
+from contextlib import contextmanager
+from time import time
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from time import time
-from contextlib import contextmanager
+from autograd import grad
 
 
 @contextmanager
@@ -39,7 +40,6 @@ def convolution():
 
 def dot_equivalent():
     # MNIST-scale convolution operation
-    import autograd.scipy.signal
 
     dat = npr.randn(256, 3, 24, 5, 24, 5)
     kernel = npr.randn(3, 5, 5)

--- a/tests/test_binary_ops.py
+++ b/tests/test_binary_ops.py
@@ -1,9 +1,10 @@
+import itertools as it
 import warnings
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-import itertools as it
-from autograd.test_util import check_grads
 from autograd import grad, value_and_grad
+from autograd.test_util import check_grads
 
 rs = npr.RandomState(0)
 
@@ -48,7 +49,7 @@ def test_mod():
     fun = lambda x, y: x % y
     make_gap_from_zero = lambda x: np.sqrt(x**2 + 0.5)
     for arg1, arg2 in arg_pairs():
-        if not arg1 is arg2:  # Gradient undefined at x == y
+        if arg1 is not arg2:  # Gradient undefined at x == y
             arg1 = make_gap_from_zero(arg1)
             arg2 = make_gap_from_zero(arg2)
             check_grads(fun)(arg1, arg2)

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -1,7 +1,7 @@
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads
 from autograd import grad
+from autograd.test_util import check_grads
 
 npr.seed(1)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 on basic operations even without numpy."""
 
 import warnings
+
 from autograd.core import make_vjp
 from autograd.wrap_util import unary_to_nary
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,9 +1,11 @@
+import operator as op
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads
-from autograd import dict as ag_dict, isinstance as ag_isinstance
+from autograd import dict as ag_dict
 from autograd import grad
-import operator as op
+from autograd import isinstance as ag_isinstance
+from autograd.test_util import check_grads
 
 npr.seed(0)
 

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -4,9 +4,10 @@ autograd.test_util break and start letting everything pass
 """
 
 import numpy as onp
-import autograd.numpy as np
-from autograd import grad, deriv, holomorphic_grad
 import pytest
+
+import autograd.numpy as np
+from autograd import deriv, grad, holomorphic_grad
 
 
 def test_grad():

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -1,9 +1,10 @@
 from functools import partial
+
+import pytest
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd.test_util import check_grads
-from autograd import grad
-import pytest
 
 npr.seed(1)
 

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -1,9 +1,11 @@
+import warnings
+
+import pytest
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads
 from autograd import grad
-import warnings
-import pytest
+from autograd.test_util import check_grads
 
 npr.seed(1)
 

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -1,7 +1,7 @@
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads
 from autograd import grad, jacobian
+from autograd.test_util import check_grads
 
 npr.seed(1)
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,12 +1,12 @@
-import itertools
+from functools import partial
+
 import numpy as onp
+import pytest
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads
 from autograd import tuple
-from autograd import grad
-from functools import partial
-import pytest
+from autograd.test_util import check_grads
 
 npr.seed(1)
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,8 +1,9 @@
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads, check_vjp, check_jvp
 from autograd import grad
-from autograd import list as ag_list, isinstance as ag_isinstance
+from autograd import isinstance as ag_isinstance
+from autograd import list as ag_list
+from autograd.test_util import check_grads
 
 npr.seed(1)
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,11 +1,13 @@
-from contextlib import contextmanager
-import pytest
 import warnings
+from contextlib import contextmanager
+
+import pytest
+
 import autograd.numpy as np
-from autograd import grad, deriv
+from autograd import deriv, grad
+from autograd.core import primitive_vjps
 from autograd.extend import primitive
 from autograd.test_util import check_grads
-from autograd.core import primitive_vjps
 
 
 def test_assert():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,9 +1,9 @@
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import scalar_close
-from autograd import make_vjp, grad
-from autograd.tracer import primitive
+from autograd import grad, make_vjp
 from autograd.misc import const_graph, flatten
+from autograd.test_util import scalar_close
+from autograd.tracer import primitive
 
 
 def test_const_graph():

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,10 +1,11 @@
 import warnings
 
+from numpy_utils import combo_check
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads
 from autograd import grad
-from numpy_utils import combo_check
+from autograd.test_util import check_grads
 
 npr.seed(1)
 

--- a/tests/test_scalar_ops.py
+++ b/tests/test_scalar_ops.py
@@ -1,7 +1,7 @@
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads
 from autograd import grad
+from autograd.test_util import check_grads
 
 npr.seed(1)
 

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 import numpy as npo
 
 try:
@@ -8,19 +9,19 @@ except:
 
     warn("Skipping scipy tests.")
 else:
-    import autograd.numpy as np
-    import autograd.numpy.random as npr
-    import autograd.scipy.signal
-    import autograd.scipy.stats as stats
-    import autograd.scipy.stats.multivariate_normal as mvn
-    import autograd.scipy.special as special
-    import autograd.scipy.linalg as spla
-    import autograd.scipy.integrate as integrate
-    from autograd import grad
+    from numpy_utils import unary_ufunc_check
     from scipy.signal import convolve as sp_convolve
 
-    from autograd.test_util import combo_check, check_grads
-    from numpy_utils import unary_ufunc_check
+    import autograd.numpy as np
+    import autograd.numpy.random as npr
+    import autograd.scipy.integrate as integrate
+    import autograd.scipy.linalg as spla
+    import autograd.scipy.signal
+    import autograd.scipy.special as special
+    import autograd.scipy.stats as stats
+    import autograd.scipy.stats.multivariate_normal as mvn
+    from autograd import grad
+    from autograd.test_util import check_grads, combo_check
 
     npr.seed(1)
     R = npr.randn

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -1,8 +1,10 @@
-import numpy as onp
-import autograd.numpy.random as npr
-import autograd.numpy as np
 import operator as op
-from numpy_utils import stat_check, unary_ufunc_check, binary_ufunc_check, binary_ufunc_check_no_same_args
+
+import numpy as onp
+from numpy_utils import binary_ufunc_check, binary_ufunc_check_no_same_args, stat_check, unary_ufunc_check
+
+import autograd.numpy as np
+import autograd.numpy.random as npr
 from autograd.test_util import combo_check
 
 npr.seed(0)

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,7 +1,8 @@
-from autograd.tracer import primitive, getval
+from pytest import raises
+
 from autograd.extend import defvjp
 from autograd.test_util import check_grads
-from pytest import raises
+from autograd.tracer import primitive
 
 
 def test_check_vjp_1st_order_fail():

--- a/tests/test_truediv.py
+++ b/tests/test_truediv.py
@@ -1,9 +1,9 @@
 # This file is to check that future division works.
 
+from test_binary_ops import arg_pairs
+
 import autograd.numpy as np
 from autograd.test_util import check_grads
-from autograd import grad
-from test_binary_ops import arg_pairs
 
 
 def test_div():

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -1,8 +1,9 @@
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads
-from autograd import tuple as ag_tuple, isinstance as ag_isinstance
 from autograd import grad
+from autograd import isinstance as ag_isinstance
+from autograd import tuple as ag_tuple
+from autograd.test_util import check_grads
 
 npr.seed(1)
 

--- a/tests/test_vspaces.py
+++ b/tests/test_vspaces.py
@@ -1,9 +1,10 @@
-from functools import reduce
-from autograd.core import vspace
-from autograd.numpy.numpy_vspaces import ArrayVSpace
-from autograd.test_util import check_grads, scalar_close
-import numpy as np
 import itertools as it
+from functools import reduce
+
+import numpy as np
+
+from autograd.core import vspace
+from autograd.test_util import check_grads, scalar_close
 
 
 def check_vspace(value):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,23 +1,24 @@
 import warnings
 from functools import partial
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import check_grads, check_equivalent  # , nd
-from autograd.tracer import primitive, isbox
 from autograd import (
-    grad,
-    elementwise_grad,
-    jacobian,
-    value_and_grad,
-    hessian_tensor_product,
-    hessian,
-    make_hvp,
-    tensor_jacobian_product,
     checkpoint,
-    make_jvp,
-    make_ggnvp,
+    elementwise_grad,
+    grad,
     grad_and_aux,
+    hessian,
+    hessian_tensor_product,
+    jacobian,
+    make_ggnvp,
+    make_hvp,
+    make_jvp,
+    tensor_jacobian_product,
+    value_and_grad,
 )
+from autograd.test_util import check_equivalent, check_grads  # , nd
+from autograd.tracer import isbox
 
 npr.seed(1)
 
@@ -158,7 +159,7 @@ def test_hessian_matrix_product():
     check_equivalent(np.tensordot(H, V), hessian_tensor_product(fun)(a, V))
 
 
-def test_hessian_tensor_product():
+def test_hessian_tensor_product_3d():
     fun = lambda a: np.sum(np.sin(a))
     a = npr.randn(5, 4, 3)
     V = npr.randn(5, 4, 3)
@@ -408,8 +409,6 @@ def test_wrapped_name_and_docs():
     assert grad.__name__ == "grad"
     # Python 3.13: Compiler now strip indents from docstrings.
     # https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes
-    assert grad.__doc__.startswith(
-        tuple(f"\n{indent}Returns a function which" for indent in ("    ", ""))
-    )
+    assert grad.__doc__.startswith(tuple(f"\n{indent}Returns a function which" for indent in ("    ", "")))
     assert grad(foo, 1).__name__ == "grad_of_foo_wrt_argnum_1"
     assert grad(foo, 1).__doc__.startswith("    grad of function foo with")


### PR DESCRIPTION
## Description

Continuing from #633, this PR adds support for the `pre-commit` via its configuration file, which works with https://pre-commit.ci. More information to help make review(s) for this PR easier:
- I have suppressed all failing rules to get `pre-commit` passing in 68e3dda41ebdaa576f1c14a4e3b02123db955f8a, so that we can fix them all later.
- At most, the style changes in this PR come from 0f7bce400ee461606588f2b6cf777bd620a990cc, where the imports have been tidied up and sorted using the `ruff check . --select I --fix && ruff format .` command.
- The pre-commit config configuration file was added in 5da63089eeabf399a23882386b25eb6aaac14efb. Please let me know if we need to add any more hooks! This is the only relevant commit, the other commits are just for stylistic changes because I didn't want to let CI fail here.

Additionally, to automatically enable `pre-commit` as a Git hook locally, type:

```bash
pip install pre-commit
pre-commit install
```

and subsequently, it would not allow creating commits that fail the style rules we have set in `pyproject.toml` or those in `.pre-commit-config.yaml`.

