### PR TITLE
[Feat] Add support for index tricks in autograd numpy

### DIFF
--- a/autograd/numpy/__init__.py
+++ b/autograd/numpy/__init__.py
@@ -1,2 +1,7 @@
 from . import fft, linalg, numpy_boxes, numpy_jvps, numpy_vjps, numpy_vspaces, random
 from .numpy_wrapper import *
+from numpy import (
+    diag_indices_from, diag_indices, fill_diagonal, ndindex, ndenumerate,
+    ix_, c_, r_, s_, ogrid, mgrid, unravel_index, ravel_multi_index,
+    index_exp
+)


### PR DESCRIPTION
As requested in https://github.com/HIPS/autograd/issues/623 I had a look at adding support for `np.mgrid` and a few other index tricks. Just importing them in `numpy.__init__` makes them available but I'm not sure how much value that actually adds. What is your opinion @agriyakhetarpal ?