### PR TITLE
Add `__array_namespace__` to `ArrayBox`

### DIFF
--- a/autograd/numpy/numpy_boxes.py
+++ b/autograd/numpy/numpy_boxes.py
@@ -1,6 +1,7 @@
+from typing import Union
+
 import numpy as np
 
-from typing import Union
 from autograd.builtins import SequenceBox
 from autograd.extend import Box, primitive
 

--- a/autograd/numpy/numpy_boxes.py
+++ b/autograd/numpy/numpy_boxes.py
@@ -23,6 +23,9 @@ class ArrayBox(Box):
     dtype = property(lambda self: self._value.dtype)
     T = property(lambda self: anp.transpose(self))
 
+    def __array_namespace__(self, *, api_version: str | None = None):
+        return anp
+
     def __len__(self):
         return len(self._value)
 

--- a/autograd/numpy/numpy_boxes.py
+++ b/autograd/numpy/numpy_boxes.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from typing import Union
 from autograd.builtins import SequenceBox
 from autograd.extend import Box, primitive
 
@@ -23,7 +24,7 @@ class ArrayBox(Box):
     dtype = property(lambda self: self._value.dtype)
     T = property(lambda self: anp.transpose(self))
 
-    def __array_namespace__(self, *, api_version: str | None = None):
+    def __array_namespace__(self, *, api_version: Union[str, None] = None):
         return anp
 
     def __len__(self):


### PR DESCRIPTION
Small change that adds the `__array_namespace__` method from the [Array API standard](https://data-apis.org/array-api/2022.12/API_specification/generated/array_api.array.__array_namespace__.html) to autograd's `ArrayBox`.

This makes autograd (partially) compatible with libraries that check for array API compatibility, such as [xarray](https://github.com/pydata/xarray), because xarray will coerce types that do not implement the array API into regular numpy arrays, see relevant discussion [here](https://github.com/pydata/xarray/issues/7848).

The following code snippet:
```python
import xarray as xr

import autograd.numpy as np
from autograd import grad


def f(x):
    data = xr.DataArray(x, dims=range(x.ndim)).data
    print(data)
    return np.sum(data)


x = np.random.uniform(-1, 1, 10)
grad(f)(x)
```
prints
```
[<autograd.numpy.numpy_boxes.ArrayBox object at 0x7f9465347640>
 <autograd.numpy.numpy_boxes.ArrayBox object at 0x7f94652f7000>
 <autograd.numpy.numpy_boxes.ArrayBox object at 0x7f94652f7c40>]
```
currently, because the traced `ArrayBox` is being coerced into a regular numpy array of `dtype=object` with `ArrayBox` elements. Differentiating through this works (with some limitations), but is very inefficient.

With the addition suggested in this PR, the snippet instead prints:
```
Autograd ArrayBox with value [1. 1. 1.]
```
i.e. `data` is now a "proper" `ArrayBox`.

I might also be interested in working on a full xarray wrapper in the future, but for now just this change would already help a lot.