### PR TITLE
chore: drop Python 3.8 and start testing against Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version:
-          ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+          ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
         # TODO: disable nightly NumPy tests for now, re-enable later
         # nightly: [[True, "nightly-"], [False, ""]]
     steps:
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/setup-python@v5.1.1
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - uses: yezz123/setup-uv@v4
 
       - name: Run CPython tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "autograd"
 version = "1.7.0"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 description = "Efficiently computes derivatives of NumPy code."
 readme = "README.md"
 license = {file = "license.txt"}
@@ -25,11 +25,11 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
 ]
 keywords = [


### PR DESCRIPTION
## Description

I was working on #643 and realised that we should now drop Python 3.8 since it has passed its EoL date, now. I also added Python 3.13 to the testing configuration here and updated the related metadata for this in `pyproject.toml`.