### PR TITLE
Pin to NumPy <3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = [
   "SciPy",
 ]
 dependencies = [
-  "numpy",
+  "numpy<3",
 ]
 # dynamic = ["version"]
 


### PR DESCRIPTION
This change is as discussed between @j-towns, @fjosw, and me; and subsequently posted publicly in https://github.com/HIPS/autograd/pull/643#issuecomment-2414374600. Pinning to NumPy <= 2.3 would also be an ideal option, but we have opted for a more relaxed pin to NumPy <3, owing to the fact that we have limited availability to add new features and hence fewer chances of anything major breaking.

This change should be merged after #643, and has been split from it because it is not directly related to the proposition of adding tests against nightly dependencies.