### PR TITLE
[Fix] Remove scipy.misc

### DIFF
--- a/autograd/scipy/__init__.py
+++ b/autograd/scipy/__init__.py
@@ -1,6 +1,1 @@
 from . import integrate, signal, special, stats
-
-try:
-    from . import misc
-except ImportError:
-    pass

--- a/autograd/scipy/misc.py
+++ b/autograd/scipy/misc.py
@@ -1,6 +1,0 @@
-import scipy.misc as osp_misc
-
-from ..scipy import special
-
-if hasattr(osp_misc, "logsumexp"):
-    logsumexp = special.logsumexp

--- a/examples/fluidsim/fluidsim.py
+++ b/examples/fluidsim/fluidsim.py
@@ -2,7 +2,7 @@ import os
 
 import matplotlib
 import matplotlib.pyplot as plt
-from scipy.misc import imread
+from matplotlib.pyplot import imread
 from scipy.optimize import minimize
 
 import autograd.numpy as np


### PR DESCRIPTION
With the latest scipy 1.15 release `scipy.misc` was deprecated which triggers a warning in autograd:
```
DeprecationWarning: scipy.misc is deprecated and will be removed in 2.0.0
    import scipy.misc as osp_misc
```

We only use the misc module to provide `logsumexp` which has been moved to `scipy.special` many years ago, so removing the functionality should not change anything for users on python>=3.9.

I also changed the import in the fluidsim example ([imread](https://docs.scipy.org/doc/scipy-1.2.3/reference/generated/scipy.ndimage.imread.html#scipy.ndimage.imread) is deprecated in SciPy 1.0.0. Use matplotlib.pyplot.imread instead)