### PR TITLE
Add Linux arm64 CI, pin GitHub Actions to hashes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,10 +28,10 @@ jobs:
       # - lint
         - validate-package
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5.1.1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
 
-    - uses: yezz123/setup-uv@v4
+    - uses: yezz123/setup-uv@ab6be5a42627f19dc36e57b548592a5e52cece4a # v4.1
 
     - name: Run ${{ matrix.env }}
       run: uvx nox -s ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
     name: Build sdist and wheel
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       name: Checkout repository
 
-    - uses: actions/setup-python@v5.1.1
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: "3.12"
 
@@ -26,7 +26,7 @@ jobs:
         pipx run build --outdir dist
 
     - name: Upload wheel and sdist artifacts
-      uses: actions/upload-artifact@v4.3.6
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: artifacts
         path: ./dist/*
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: dist
           merge-multiple: true
@@ -53,6 +53,6 @@ jobs:
         run: ls -la dist/
 
       - name: Publish sdist and wheel to PyPI
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           packages-dir: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,15 +29,13 @@ jobs:
         platform: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version:
           ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
-        # TODO: disable nightly NumPy tests for now, re-enable later
-        # nightly: [[True, "nightly-"], [False, ""]]
     steps:
-      - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: yezz123/setup-uv@v4
+      - uses: yezz123/setup-uv@ab6be5a42627f19dc36e57b548592a5e52cece4a # v4.1
 
       # On PyPy, we skip SciPy because we don't have wheels
       # available, see noxfile.py for more details.
@@ -64,11 +62,11 @@ jobs:
         python-version: ["3.x"]
 
     steps:
-      - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: yezz123/setup-uv@v4
+      - uses: yezz123/setup-uv@ab6be5a42627f19dc36e57b548592a5e52cece4a # v4.1
       - name: Run tests against nightly wheels for NumPy and SciPy
         run: uvx nox -s nightly-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,13 @@ jobs:
         platform: [ubuntu-latest, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
         python-version:
           ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
+        # PyPy for Linux arm64 hasn't made it to a new release yet, see
+        # https://github.com/actions/setup-python/pull/1011
+        exclude:
+        - platform: ubuntu-22.04-arm
+          python-version: "pypy-3.9"
+        - platform: ubuntu-22.04-arm
+          python-version: "pypy-3.10"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        platform: [ubuntu-latest, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
         python-version:
           ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
     steps:
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        platform: [ubuntu-latest, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
         python-version: ["3.x"]
 
     steps:


### PR DESCRIPTION
# Description

- Linux arm64 runners are now generally available for GitHub Actions usage.
- Pins all GitHub Actions used to their hashes instead of using their versions.

# Additional context

- https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions