### PR TITLE
Export NumPy version from Autograd wrapper

### DIFF
--- a/autograd/numpy/__init__.py
+++ b/autograd/numpy/__init__.py
@@ -1,2 +1,3 @@
 from . import fft, linalg, numpy_boxes, numpy_jvps, numpy_vjps, numpy_vspaces, random
 from .numpy_wrapper import *
+from .numpy_wrapper import numpy_version as __version__

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -10,6 +10,8 @@ if _np.lib.NumpyVersion(_np.__version__) >= "2.0.0":
 else:
     from numpy.core.einsumfunc import _parse_einsum_input
 
+numpy_version = _np.__version__
+
 notrace_functions = [_np.ndim, _np.shape, _np.iscomplexobj, _np.result_type]
 
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -10,6 +10,12 @@ from autograd.test_util import check_grads
 npr.seed(1)
 
 
+def test_numpy_version():
+    import numpy
+
+    assert np.__version__ == numpy.__version__
+
+
 def test_dot():
     def fun(x, y):
         return np.dot(x, y)


### PR DESCRIPTION
Closes #679; `autograd.numpy.__version__` will now display the underlying NumPy version.