### PR TITLE
Enable PyPy tests on Linux arm64, and remove `pypy-3.9`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
         - validate-package
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
 
     - uses: yezz123/setup-uv@ab6be5a42627f19dc36e57b548592a5e52cece4a # v4.1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       name: Checkout repository
 
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.12"
 
@@ -26,7 +26,7 @@ jobs:
         pipx run build --outdir dist
 
     - name: Upload wheel and sdist artifacts
-      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: artifacts
         path: ./dist/*
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,17 +28,10 @@ jobs:
       matrix:
         platform: [ubuntu-latest, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
         python-version:
-          ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
-        # PyPy for Linux arm64 hasn't made it to a new release yet, see
-        # https://github.com/actions/setup-python/pull/1011
-        exclude:
-        - platform: ubuntu-22.04-arm
-          python-version: "pypy-3.9"
-        - platform: ubuntu-22.04-arm
-          python-version: "pypy-3.10"
+          ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10", "pypy-3.11"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -70,7 +63,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
         python-version:
-          ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10", "pypy-3.11"]
+          ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
         python-version:
-          ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10", "pypy-3.11"]
+          ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10", "pypy-3.11"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
# Description

- PyPy is now available on the `ubuntu-22.04-arm` images
- PyPy has now dropped Python 3.9 since PyPy 7.3.17, see https://pypy.org/posts/2025/02/pypy-v7319-release.html
- ~PyPy's Python 3.11 can now be tested~ NumPy wheels for "pypy-3.11" are not available yet, so we should wait for this to happen.
