### PR TITLE
Fix np.absolute grads

### DIFF
--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -106,9 +106,10 @@ defjvp(anp.broadcast_to, "same")
 def_linear(anp.cross)
 
 # ----- Simple grads -----
-defjvp(anp.abs, lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0))
+np_abs_jvp = lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0)
+defjvp(anp.abs, np_abs_jvp)
+defjvp(anp.absolute, np_abs_jvp)
 defjvp(anp.fabs, lambda g, ans, x: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defjvp(anp.absolute, lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0))
 defjvp(anp.reciprocal, lambda g, ans, x: -g / x**2)
 defjvp(anp.exp, lambda g, ans, x: ans * g)
 defjvp(anp.exp2, lambda g, ans, x: ans * anp.log(2) * g)

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -108,7 +108,7 @@ def_linear(anp.cross)
 # ----- Simple grads -----
 defjvp(anp.abs, lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0))
 defjvp(anp.fabs, lambda g, ans, x: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defjvp(anp.absolute, lambda g, ans, x: anp.real(g * anp.conj(x)) / ans)
+defjvp(anp.absolute, lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0))
 defjvp(anp.reciprocal, lambda g, ans, x: -g / x**2)
 defjvp(anp.exp, lambda g, ans, x: ans * g)
 defjvp(anp.exp2, lambda g, ans, x: ans * anp.log(2) * g)

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -155,7 +155,7 @@ defvjp(
 defvjp(anp.negative, lambda ans, x: lambda g: -g)
 defvjp(anp.abs, lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0))
 defvjp(anp.fabs, lambda ans, x: lambda g: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defvjp(anp.absolute, lambda ans, x: lambda g: g * anp.conj(x) / ans)
+defvjp(anp.absolute, lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0))
 defvjp(anp.reciprocal, lambda ans, x: lambda g: -g / x**2)
 defvjp(anp.exp, lambda ans, x: lambda g: ans * g)
 defvjp(anp.exp2, lambda ans, x: lambda g: ans * anp.log(2) * g)

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -153,9 +153,10 @@ defvjp(
 # ----- Simple grads -----
 
 defvjp(anp.negative, lambda ans, x: lambda g: -g)
-defvjp(anp.abs, lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0))
+np_abs_vjp = lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0)
+defvjp(anp.abs, np_abs_vjp)
+defvjp(anp.absolute, np_abs_vjp)
 defvjp(anp.fabs, lambda ans, x: lambda g: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defvjp(anp.absolute, lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0))
 defvjp(anp.reciprocal, lambda ans, x: lambda g: -g / x**2)
 defvjp(anp.exp, lambda ans, x: lambda g: ans * g)
 defvjp(anp.exp2, lambda ans, x: lambda g: ans * anp.log(2) * g)

--- a/tests/test_scalar_ops.py
+++ b/tests/test_scalar_ops.py
@@ -13,6 +13,13 @@ def test_abs():
     check_grads(fun, order=1)(0.0)
 
 
+def test_absolute():
+    fun = lambda x: 3.0 * np.absolute(x)
+    check_grads(fun)(1.1)
+    check_grads(fun)(-1.1)
+    check_grads(fun, order=1)(0.0)
+
+
 def test_sin():
     fun = lambda x: 3.0 * np.sin(x)
     check_grads(fun)(npr.randn())


### PR DESCRIPTION
`np.abs` is just shorthand for `np.absolute`, however only the former had previously received the required special care for handling avoiding division by zero.