### PR TITLE
wrap_namespace maps multiple names of the same object to the same wrapped object

### DIFF
--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -106,9 +106,10 @@ defjvp(anp.broadcast_to, "same")
 def_linear(anp.cross)
 
 # ----- Simple grads -----
-defjvp(anp.abs, lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0))
+np_abs_jvp = lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0)
+defjvp(anp.abs, np_abs_jvp)
+defjvp(anp.absolute, np_abs_jvp)
 defjvp(anp.fabs, lambda g, ans, x: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defjvp(anp.absolute, lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0))
 defjvp(anp.reciprocal, lambda g, ans, x: -g / x**2)
 defjvp(anp.exp, lambda g, ans, x: ans * g)
 defjvp(anp.exp2, lambda g, ans, x: ans * anp.log(2) * g)

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -108,7 +108,7 @@ def_linear(anp.cross)
 # ----- Simple grads -----
 defjvp(anp.abs, lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0))
 defjvp(anp.fabs, lambda g, ans, x: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defjvp(anp.absolute, lambda g, ans, x: anp.real(g * anp.conj(x)) / ans)
+defjvp(anp.absolute, lambda g, ans, x: anp.real(g * replace_zero(anp.conj(x), 0.0)) / replace_zero(ans, 1.0))
 defjvp(anp.reciprocal, lambda g, ans, x: -g / x**2)
 defjvp(anp.exp, lambda g, ans, x: ans * g)
 defjvp(anp.exp2, lambda g, ans, x: ans * anp.log(2) * g)

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -155,7 +155,7 @@ defvjp(
 defvjp(anp.negative, lambda ans, x: lambda g: -g)
 defvjp(anp.abs, lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0))
 defvjp(anp.fabs, lambda ans, x: lambda g: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defvjp(anp.absolute, lambda ans, x: lambda g: g * anp.conj(x) / ans)
+defvjp(anp.absolute, lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0))
 defvjp(anp.reciprocal, lambda ans, x: lambda g: -g / x**2)
 defvjp(anp.exp, lambda ans, x: lambda g: ans * g)
 defvjp(anp.exp2, lambda ans, x: lambda g: ans * anp.log(2) * g)

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -153,9 +153,10 @@ defvjp(
 # ----- Simple grads -----
 
 defvjp(anp.negative, lambda ans, x: lambda g: -g)
-defvjp(anp.abs, lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0))
+np_abs_vjp = lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0)
+defvjp(anp.abs, np_abs_vjp)
+defvjp(anp.absolute, np_abs_vjp)
 defvjp(anp.fabs, lambda ans, x: lambda g: anp.sign(x) * g)  # fabs doesn't take complex numbers.
-defvjp(anp.absolute, lambda ans, x: lambda g: g * replace_zero(anp.conj(x), 0.0) / replace_zero(ans, 1.0))
 defvjp(anp.reciprocal, lambda ans, x: lambda g: -g / x**2)
 defvjp(anp.exp, lambda ans, x: lambda g: ans * g)
 defvjp(anp.exp2, lambda ans, x: lambda g: ans * anp.log(2) * g)

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -25,15 +25,29 @@ def wrap_intdtype(cls):
 def wrap_namespace(old, new):
     unchanged_types = {float, int, type(None), type}
     int_types = {_np.int8, _np.int16, _np.int32, _np.int64, _np.integer}
+    obj_to_wrapped = []
     for name, obj in old.items():
-        if obj in notrace_functions:
-            new[name] = notrace_primitive(obj)
-        elif callable(obj) and type(obj) is not type:
-            new[name] = primitive(obj)
-        elif type(obj) is type and obj in int_types:
-            new[name] = wrap_intdtype(obj)
-        elif type(obj) in unchanged_types:
-            new[name] = obj
+        # Map multiple names of the same object (e.g. conj/conjugate)
+        # to the same wrapped object
+        for (mapped_obj, wrapped) in obj_to_wrapped:
+            if mapped_obj is obj:
+                new[name] = wrapped
+                break
+        else:
+            if obj in notrace_functions:
+                wrapped = notrace_primitive(obj)
+                new[name] = wrapped
+                obj_to_wrapped.append((obj, wrapped))
+            elif callable(obj) and type(obj) is not type:
+                wrapped = primitive(obj)
+                new[name] = wrapped
+                obj_to_wrapped.append((obj, wrapped))
+            elif type(obj) is type and obj in int_types:
+                wrapped = wrap_intdtype(obj)
+                new[name] = wrapped
+                obj_to_wrapped.append((obj, wrapped))
+            elif type(obj) in unchanged_types:
+                new[name] = obj
 
 
 wrap_namespace(_np.__dict__, globals())

--- a/tests/test_scalar_ops.py
+++ b/tests/test_scalar_ops.py
@@ -13,6 +13,13 @@ def test_abs():
     check_grads(fun, order=1)(0.0)
 
 
+def test_absolute():
+    fun = lambda x: 3.0 * np.absolute(x)
+    check_grads(fun)(1.1)
+    check_grads(fun)(-1.1)
+    check_grads(fun, order=1)(0.0)
+
+
 def test_sin():
     fun = lambda x: 3.0 * np.sin(x)
     check_grads(fun)(npr.randn())


### PR DESCRIPTION
Avoids creating two different wrappers for the same object.

Generally cleaner, but more importantly towards better ufuncs support (coming soon), which will require mapping from ufuncs to their wrapped version.

Note this is based over #712: without it, this change would cause the wrong grads set to `anp.absolute` to overwrite the correct ones set to `anp.abs` since they are now one and the same object (since `np.abs` and `np.absolute` are).