### PR TITLE
Map multiple names of the same object to the same wrapped object

### DIFF
--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -36,18 +36,17 @@ def wrap_namespace(old, new):
         else:
             if obj in notrace_functions:
                 wrapped = notrace_primitive(obj)
-                new[name] = wrapped
-                obj_to_wrapped.append((obj, wrapped))
             elif callable(obj) and type(obj) is not type:
                 wrapped = primitive(obj)
-                new[name] = wrapped
-                obj_to_wrapped.append((obj, wrapped))
             elif type(obj) is type and obj in int_types:
                 wrapped = wrap_intdtype(obj)
-                new[name] = wrapped
-                obj_to_wrapped.append((obj, wrapped))
             elif type(obj) in unchanged_types:
                 new[name] = obj
+                continue
+            else:
+                continue
+            new[name] = wrapped
+            obj_to_wrapped.append((obj, wrapped))
 
 
 wrap_namespace(_np.__dict__, globals())


### PR DESCRIPTION
Avoid creating two different wrappers for the same object in `wrap_namespace`.

Generally cleaner, but more importantly towards better ufuncs support, which will require mapping from ufuncs to their wrapped version.

Another minor pro is that this theoretically avoids needing to define grads for two names of the same object, e.g., we could define the VJP for anp.conj but not for anp.conjugate since they are actually the same wrapped object. However, it's minor and theoretical because whether or not two "equivalent" numpy functions/ufuncs are the same object is apparently an implementation detail, e.g., `np.amax` is documented as an alias of `np.max`, but they actually aren't the same object, and the equivalent ufuncs `np.degrees` and `np.rad2deg` are two different ones (tested on numpy 2.3.1). Because this might change between different numpy version, it's more robust to keep the grad definitions for both names.