### PR TITLE
Fixup examples

### DIFF
--- a/examples/bayesian_neural_net.py
+++ b/examples/bayesian_neural_net.py
@@ -42,7 +42,7 @@ def make_nn_funs(layer_sizes, L2_reg, noise_variance, nonlinearity=np.tanh):
 def build_toy_dataset(n_data=40, noise_std=0.1):
     D = 1
     rs = npr.RandomState(0)
-    inputs = np.concatenate([np.linspace(0, 2, num=n_data / 2), np.linspace(6, 8, num=n_data / 2)])
+    inputs = np.concatenate([np.linspace(0, 2, num=n_data // 2), np.linspace(6, 8, num=n_data // 2)])
     targets = np.cos(inputs) + rs.randn(n_data) * noise_std
     inputs = (inputs - 4.0) / 4.0
     inputs = inputs.reshape((len(inputs), D))

--- a/examples/data_mnist.py
+++ b/examples/data_mnist.py
@@ -16,7 +16,7 @@ def download(url, filename):
 
 
 def mnist():
-    base_url = "http://yann.lecun.com/exdb/mnist/"
+    base_url = "https://storage.googleapis.com/cvdf-datasets/mnist/"
 
     def parse_labels(filename):
         with gzip.open(filename, "rb") as fh:

--- a/examples/gaussian_process.py
+++ b/examples/gaussian_process.py
@@ -48,7 +48,7 @@ def rbf_covariance(kernel_params, x, xp):
 
 def build_toy_dataset(D=1, n_data=20, noise_std=0.1):
     rs = npr.RandomState(0)
-    inputs = np.concatenate([np.linspace(0, 3, num=n_data / 2), np.linspace(6, 8, num=n_data / 2)])
+    inputs = np.concatenate([np.linspace(0, 3, num=n_data // 2), np.linspace(6, 8, num=n_data // 2)])
     targets = (np.cos(inputs) + rs.randn(n_data) * noise_std) / 2.0
     inputs = (inputs - 4.0) / 2.0
     inputs = inputs.reshape((len(inputs), D))

--- a/examples/negative_binomial_maxlike.py
+++ b/examples/negative_binomial_maxlike.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     xm = data.max()
     plt.figure()
-    plt.hist(data, bins=np.arange(xm + 1) - 0.5, normed=True, label="normed data counts")
+    plt.hist(data, bins=np.arange(xm + 1) - 0.5, density=True, label="normed data counts")
     plt.xlim(0, xm)
     plt.plot(np.arange(xm), np.exp(negbin_loglike(r, p, np.arange(xm))), label="maxlike fit")
     plt.xlabel("k")

--- a/examples/neural_net_regression.py
+++ b/examples/neural_net_regression.py
@@ -38,7 +38,7 @@ def logprob(weights, inputs, targets, noise_scale=0.1):
 
 def build_toy_dataset(n_data=80, noise_std=0.1):
     rs = npr.RandomState(0)
-    inputs = np.concatenate([np.linspace(0, 3, num=n_data / 2), np.linspace(6, 8, num=n_data / 2)])
+    inputs = np.concatenate([np.linspace(0, 3, num=n_data // 2), np.linspace(6, 8, num=n_data // 2)])
     targets = np.cos(inputs) + rs.randn(n_data) * noise_std
     inputs = (inputs - 4.0) / 2.0
     inputs = inputs[:, np.newaxis]

--- a/examples/rkhs.py
+++ b/examples/rkhs.py
@@ -3,6 +3,8 @@ Inferring a function from a reproducing kernel Hilbert space (RKHS) by taking
 gradients of eval with respect to the function-valued argument
 """
 
+from itertools import chain
+
 import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd import grad
@@ -71,7 +73,7 @@ RKHSFunVSpace.register(RKHSFun)
 
 def add_dicts(d1, d2):
     d = {}
-    for k, v in d1.items() + d2.items():
+    for k, v in chain(d1.items(), d2.items()):
         d[k] = d[k] + v if k in d else v
     return d
 


### PR DESCRIPTION
This project has been extremely useful for me in the past, and I was glad to learn that it is still being maintained! While dusting off some old code I noticed that some of the examples no longer work. Specifically:

- The MNIST dataset seems to have disappeared (along with nearly all other content?) from Yann LeCun's personal website. Download these from a mirror instead.
- Use floor division when constructing arguments to np.arange
- Use Matplotlib 3.0 API (normed -> density in plt.hist)
- Use Python3 dict semantics (.items() is a view rather than a list)