### PR TITLE
Replace macos-13 image with macos-15-intel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
+        platform: [ubuntu-latest, ubuntu-22.04-arm, macos-15-intel, macos-latest, windows-latest]
         python-version:
           ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10"]
     steps:
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest]
+        platform: [ubuntu-latest, ubuntu-22.04-arm, macos-15-intel, macos-latest, windows-latest]
         python-version: ["3.x"]
 
     steps:


### PR DESCRIPTION
The macos-13 image has finally been retired, and we have been seeing CI failures because the jobs are not starting. This PR replaces it with the macos-15-intel runner.