### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, ubuntu-22.04-arm, macos-15-intel, macos-latest, windows-latest]
         python-version:
-          ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10"]
+          ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,12 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
+    hooks:
+      - id: pyupgrade
+        args: [--py310-plus]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.14.8"
     hooks:

--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -81,9 +81,9 @@ def norm_vjp(ans, x, ord=None, axis=None):
 
         if matrix_norm:
             if not (ord is None or ord == "fro" or ord == "nuc"):
-                raise NotImplementedError("Gradient of matrix norm not implemented for ord={}".format(ord))
+                raise NotImplementedError(f"Gradient of matrix norm not implemented for ord={ord}")
         elif not (ord is None or ord > 1):
-            raise NotImplementedError("Gradient of norm not implemented for ord={}".format(ord))
+            raise NotImplementedError(f"Gradient of norm not implemented for ord={ord}")
 
     if axis is None:
         expand = lambda a: a
@@ -137,9 +137,9 @@ def norm_jvp(g, ans, x, ord=None, axis=None):
 
         if matrix_norm:
             if not (ord is None or ord == "fro" or ord == "nuc"):
-                raise NotImplementedError("Gradient of matrix norm not implemented for ord={}".format(ord))
+                raise NotImplementedError(f"Gradient of matrix norm not implemented for ord={ord}")
         elif not (ord is None or ord > 1):
-            raise NotImplementedError("Gradient of norm not implemented for ord={}".format(ord))
+            raise NotImplementedError(f"Gradient of norm not implemented for ord={ord}")
 
     if axis is None:
         contract = lambda a: anp.sum(a)

--- a/autograd/numpy/numpy_boxes.py
+++ b/autograd/numpy/numpy_boxes.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import numpy as np
 
 from autograd.builtins import SequenceBox
@@ -25,7 +23,7 @@ class ArrayBox(Box):
     dtype = property(lambda self: self._value.dtype)
     T = property(lambda self: anp.transpose(self))
 
-    def __array_namespace__(self, *, api_version: Union[str, None] = None):
+    def __array_namespace__(self, *, api_version: str | None = None):
         return anp
 
     def __len__(self):

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -78,7 +78,7 @@ def array(A, *args, **kwargs):
 def wrap_if_boxes_inside(raw_array, slow_op_name=None):
     if raw_array.dtype is _np.dtype("O"):
         if slow_op_name:
-            warnings.warn("{} is slow for array inputs. np.concatenate() is faster.".format(slow_op_name))
+            warnings.warn(f"{slow_op_name} is slow for array inputs. np.concatenate() is faster.")
         return array_from_args((), {}, *raw_array.ravel()).reshape(raw_array.shape)
     else:
         return raw_array

--- a/examples/fluidsim/wing.py
+++ b/examples/fluidsim/wing.py
@@ -182,7 +182,5 @@ if __name__ == "__main__":
     simulate(init_vx, init_vy, simulation_timesteps, final_occlusion, ax, render=True)
 
     print("Converting frames to an animated GIF...")  # Using imagemagick.
-    os.system(
-        "convert -delay 5 -loop 0 step*.png -delay 250 step{:03d}.png wing.gif".format(simulation_timesteps)
-    )
+    os.system(f"convert -delay 5 -loop 0 step*.png -delay 250 step{simulation_timesteps:03d}.png wing.gif")
     os.system("rm step*.png")

--- a/examples/tanh.py
+++ b/examples/tanh.py
@@ -20,7 +20,7 @@ function is vectorized.
 
 
 def tanh(x):
-    return (1.0 - np.exp((-2 * x))) / (1.0 + np.exp(-(2 * x)))
+    return (1.0 - np.exp(-2 * x)) / (1.0 + np.exp(-(2 * x)))
 
 
 ### Plotting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "autograd"
 version = "1.8.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "Efficiently computes derivatives of NumPy code."
 readme = "README.md"
 license = {file = "license.txt"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
 ]
 keywords = [


### PR DESCRIPTION
It is now EOL as per https://endoflife.date/python, so this PR updates our minimum supported Python version to 3.10. I've also added pyupgrade for some cleanup.