### PR TITLE
Add examples section with matplotlib dependency

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,24 @@
+# Autograd examples
+
+## Usage instructions
+
+Some of the examples require additional dependencies beyond Autograd and its
+core dependencies. These are set up under the `examples` dependency group. To
+install them, navigate to the root directory of where you cloned Autograd and
+run
+```sh
+pip install --group examples
+```
+from the command line. Note that dependency groups are a recent feature so you
+may need to upgrade `pip` with
+```sh
+pip install --upgrade pip
+```
+
+Having installed the additional dependencies, you may navigate to the `examples`
+subdirectory and run any of the Python scripts. For example:
+```sh
+python3 tanh.py
+```
+Some of the examples print to the terminal and others open pop-up windows for
+plots.

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,11 +28,11 @@ def check(session):
 @nox.session(name="tests", tags=["tests"])
 def run_tests(session):
     """Run unit tests and generate a coverage report"""
+    pyproject = nox.project.load_toml("pyproject.toml")
+    session.install(*nox.project.dependency_groups(pyproject, "test"))
     # SciPy doesn't have wheels on PyPy
-    if platform.python_implementation() == "PyPy":
-        session.install("-e", ".[test]", silent=False)
-    else:
-        session.install("-e", ".[test,scipy]", silent=False)
+    if platform.python_implementation() != "PyPy":
+        session.install("-e", ".[scipy]", silent=False)
     session.run("pytest", "--cov=autograd", "--cov-report=xml", "--cov-append", *session.posargs)
 
 
@@ -46,7 +46,8 @@ def ruff(session):
 @nox.session(name="nightly-tests", tags=["tests"])
 def run_nightly_tests(session):
     """Run tests against nightly versions of dependencies"""
-    session.install("-e", ".[test]", silent=False)
+    pyproject = nox.project.load_toml("pyproject.toml")
+    session.install(*nox.project.dependency_groups(pyproject, "test"))
     # SciPy doesn't have wheels on PyPy
     if platform.python_implementation() == "PyPy":
         session.install(

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,9 @@ def run_tests(session):
     pyproject = nox.project.load_toml("pyproject.toml")
     session.install(*nox.project.dependency_groups(pyproject, "test"))
     # SciPy doesn't have wheels on PyPy
-    if platform.python_implementation() != "PyPy":
+    if platform.python_implementation() == "PyPy":
+        session.install("-e.", silent=False)
+    else:
         session.install("-e", ".[scipy]", silent=False)
     session.run("pytest", "--cov=autograd", "--cov-report=xml", "--cov-append", *session.posargs)
 
@@ -46,6 +48,7 @@ def ruff(session):
 @nox.session(name="nightly-tests", tags=["tests"])
 def run_nightly_tests(session):
     """Run tests against nightly versions of dependencies"""
+    session.install("-e.", silent=False)
     pyproject = nox.project.load_toml("pyproject.toml")
     session.install(*nox.project.dependency_groups(pyproject, "test"))
     # SciPy doesn't have wheels on PyPy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,14 @@ Source = "https://github.com/HIPS/autograd"
 scipy = [
   "scipy",
 ]
+
+[dependency-groups]
 test = [
   "pytest",
   "pytest-cov",
   "pytest-xdist",
 ]
-examples = [
-  "matplotlib",
-]
+examples = ["matplotlib"]
 
 [tool.coverage.run]
 source = ["autograd"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ test = [
   "pytest-cov",
   "pytest-xdist",
 ]
+examples = [
+  "matplotlib",
+]
 
 [tool.coverage.run]
 source = ["autograd"]


### PR DESCRIPTION
Hi, thanks for developing this package, it seems like it'll be really useful.

I tried to run some of the examples and noticed that `matplotlib` is required but not included in the dependencies. I'm not completely sure of how the optional dependencies work in `pyproject.toml` but perhaps this is sufficient?