### PR TITLE
Fix `np.mean`, `std`, `var`, and `linalg.norm` with `list`/`tuple` containing `ArrayBox` objects

### DIFF
--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -88,7 +88,7 @@ def grad_solve(argnum, ans, a, b):
 defvjp(solve, partial(grad_solve, 0), partial(grad_solve, 1))
 
 
-def norm_vjp(ans, x, ord=None, axis=None):
+def norm_vjp(ans, x, ord=None, axis=None, **kwargs):
     def check_implemented():
         matrix_norm = (x.ndim == 2 and axis is None) or isinstance(axis, tuple)
 
@@ -144,7 +144,7 @@ def norm_vjp(ans, x, ord=None, axis=None):
 defvjp(_primitive_norm, norm_vjp)
 
 
-def norm_jvp(g, ans, x, ord=None, axis=None):
+def norm_jvp(g, ans, x, ord=None, axis=None, **kwargs):
     def check_implemented():
         matrix_norm = (x.ndim == 2 and axis is None) or isinstance(axis, tuple)
 

--- a/autograd/numpy/linalg.py
+++ b/autograd/numpy/linalg.py
@@ -2,12 +2,25 @@ from functools import partial
 
 import numpy.linalg as npla
 
+import autograd.builtins as builtins
 from autograd.extend import defjvp, defvjp
 
 from . import numpy_wrapper as anp
 from .numpy_wrapper import wrap_namespace
 
 wrap_namespace(npla.__dict__, globals())
+
+
+# Store the primitive-wrapped norm for internal use; see numpy_wrapper.mean
+# for the same list/tuple-of-ArrayBox workaround.
+_primitive_norm = norm
+
+
+def norm(x, *args, **kwargs):
+    if builtins.type(x) in (list, tuple):
+        x = anp.array(x)
+    return _primitive_norm(x, *args, **kwargs)
+
 
 # Some formulas are from
 # "An extended collection of matrix derivative results
@@ -128,7 +141,7 @@ def norm_vjp(ans, x, ord=None, axis=None):
     return vjp
 
 
-defvjp(norm, norm_vjp)
+defvjp(_primitive_norm, norm_vjp)
 
 
 def norm_jvp(g, ans, x, ord=None, axis=None):
@@ -174,7 +187,7 @@ def norm_jvp(g, ans, x, ord=None, axis=None):
         return contract(g * anp.conj(x) * anp.abs(x) ** (ord - 2)) / ans ** (ord - 1)
 
 
-defjvp(norm, norm_jvp)
+defjvp(_primitive_norm, norm_jvp)
 
 
 def grad_eigh(ans, x, UPLO="L"):

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -159,7 +159,7 @@ defjvp(anp.repeat, "same")
 defjvp(anp.tile, "same")
 defjvp(anp.transpose, "same")
 defjvp(anp.sum, "same")
-defjvp(anp.mean, "same")
+defjvp(anp._primitive_mean, "same")
 defjvp(
     anp.prod, lambda g, ans, x, axis=None, keepdims=False: ans * anp.sum(g / x, axis=axis, keepdims=keepdims)
 )

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -170,7 +170,7 @@ defjvp(
 )
 
 
-def forward_grad_np_var(g, ans, x, axis=None, ddof=0, keepdims=False):
+def forward_grad_np_var(g, ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
     if axis is None:
         num_reps = anp.size(g)
     elif isinstance(axis, int):
@@ -185,7 +185,7 @@ def forward_grad_np_var(g, ans, x, axis=None, ddof=0, keepdims=False):
 defjvp(anp._primitive_var, forward_grad_np_var)
 
 
-def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False):
+def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
     if axis is None:
         num_reps = anp.size(g)
     elif isinstance(axis, int):

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -182,7 +182,7 @@ def forward_grad_np_var(g, ans, x, axis=None, ddof=0, keepdims=False):
     return 2.0 * anp.sum(anp.real(g * x_minus_mean), axis=axis, keepdims=keepdims) / (num_reps - ddof)
 
 
-defjvp(anp.var, forward_grad_np_var)
+defjvp(anp._primitive_var, forward_grad_np_var)
 
 
 def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False):
@@ -199,7 +199,7 @@ def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False):
     return anp.sum(anp.real(g * x_minus_mean), axis=axis, keepdims=keepdims) / ((num_reps - ddof) * ans)
 
 
-defjvp(anp.std, forward_grad_np_std)
+defjvp(anp._primitive_std, forward_grad_np_std)
 
 
 def fwd_grad_chooser(g, ans, x, axis=None, keepdims=False):

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -448,7 +448,7 @@ def grad_np_sum(ans, x, axis=None, keepdims=False, dtype=None):
 defvjp(anp.sum, grad_np_sum)
 
 
-def grad_np_mean(ans, x, axis=None, keepdims=False):
+def grad_np_mean(ans, x, axis=None, keepdims=False, **kwargs):
     shape, dtype = anp.shape(x), anp.result_type(x)
 
     def vjp(g):
@@ -458,7 +458,7 @@ def grad_np_mean(ans, x, axis=None, keepdims=False):
     return vjp
 
 
-defvjp(anp.mean, grad_np_mean)
+defvjp(anp._primitive_mean, grad_np_mean)
 
 
 def grad_np_prod(ans, x, axis=None, keepdims=False):  # TODO: Support tuples of axes.

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -487,7 +487,7 @@ def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False):
     return vjp
 
 
-defvjp(anp.var, grad_np_var)
+defvjp(anp._primitive_var, grad_np_var)
 
 
 def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False):
@@ -509,7 +509,7 @@ def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False):
     return vjp
 
 
-defvjp(anp.std, grad_np_std)
+defvjp(anp._primitive_std, grad_np_std)
 
 
 def grad_chooser(ans, x, axis=None, keepdims=None):

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -474,7 +474,7 @@ def grad_np_prod(ans, x, axis=None, keepdims=False):  # TODO: Support tuples of 
 defvjp(anp.prod, grad_np_prod)
 
 
-def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False):
+def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
     shape, _, dtype, iscomplex = anp.metadata(x)
 
     def vjp(g):
@@ -490,7 +490,7 @@ def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False):
 defvjp(anp._primitive_var, grad_np_var)
 
 
-def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False):
+def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
     shape, _, dtype, iscomplex = anp.metadata(x)
 
     def vjp(g):

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -190,3 +190,18 @@ else:
     @primitive
     def _astype(A, dtype, order="K", casting="unsafe", subok=True, copy=True):
         return A.astype(dtype, order, casting, subok, copy)
+
+
+# Store the primitive-wrapped mean for internal use
+_primitive_mean = mean
+
+
+def mean(a, *args, **kwargs):
+    """Wrapper that converts list/tuple to array before computing mean.
+
+    This is needed because numpy's internal mean implementation calls
+    float() on the result, which fails for ArrayBox objects.
+    """
+    if builtins.type(a) in (list, tuple):
+        a = array(a)
+    return _primitive_mean(a, *args, **kwargs)

--- a/autograd/numpy/numpy_wrapper.py
+++ b/autograd/numpy/numpy_wrapper.py
@@ -205,3 +205,19 @@ def mean(a, *args, **kwargs):
     if builtins.type(a) in (list, tuple):
         a = array(a)
     return _primitive_mean(a, *args, **kwargs)
+
+
+_primitive_std = std
+_primitive_var = var
+
+
+def std(a, *args, **kwargs):
+    if builtins.type(a) in (list, tuple):
+        a = array(a)
+    return _primitive_std(a, *args, **kwargs)
+
+
+def var(a, *args, **kwargs):
+    if builtins.type(a) in (list, tuple):
+        a = array(a)
+    return _primitive_var(a, *args, **kwargs)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -175,6 +175,14 @@ def test_vector_2norm():
     check_grads(fun, modes=["fwd", "rev"])(vec)
 
 
+def test_norm_list_of_boxes():
+    from autograd import grad
+
+    # d/dx sqrt(x**2 + (x + 2)**2) at x=0 is 2/sqrt(4) = 1.
+    assert grad(lambda x: np.linalg.norm([x, x + 2]))(0.0) == 1.0
+    assert grad(lambda x: np.linalg.norm((x, x + 2)))(0.0) == 1.0
+
+
 def test_vector_2norm_complex():
     def fun(x):
         return np.linalg.norm(x)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -243,6 +243,22 @@ def test_mean_3():
     check_grads(fun)(mat)
 
 
+def test_mean_list_of_boxes():
+    assert grad(lambda x: np.mean([x, x + 2]))(0.0) == 1.0
+    assert grad(lambda x: np.mean((x, x + 2)))(0.0) == 1.0
+
+
+def test_std_list_of_boxes():
+    # Symmetric around the mean, so grad w.r.t. x at x=0 is 0.
+    assert grad(lambda x: np.std([x, x + 2]))(0.0) == 0.0
+    assert grad(lambda x: np.std((x, x + 2)))(0.0) == 0.0
+
+
+def test_var_list_of_boxes():
+    assert grad(lambda x: np.var([x, x + 2]))(0.0) == 0.0
+    assert grad(lambda x: np.var((x, x + 2)))(0.0) == 0.0
+
+
 def test_index_ints():
     A = npr.randn(5, 6, 4)
 


### PR DESCRIPTION
## Summary

Fix `autograd.numpy.mean()` failing when passed a list/tuple containing `ArrayBox` objects.

```python
import autograd
import autograd.numpy as np

def f(x):
    return np.mean([x, x+2])

g = autograd.grad(f)
g(0.0)  # Previously raised TypeError, now returns 1.0
```

Previously raised: `TypeError: float() argument must be a string or a real number, not 'ArrayBox'`

##  Root cause

When `np.mean()` receives a list containing `ArrayBox` objects,` numpy`'s internal `_mean` implementation calls `ret.dtype.type(result)` to cast the output. 

Since `ArrayBox.dtype` returns `float64`, this becomes `np.float64(ArrayBox)`, which calls `float()` on the `ArrayBox` and fails.

##  Fix

- Add a `mean` wrapper that converts `list`/`tuple` inputs to arrays using autograd's
  `array()` function before calling the primitive
- Update VJP/JVP registrations to use `_primitive_mean` (the underlying primitive)
- Add `**kwargs` to `grad_np_mean` to accept optional arguments like `dtype`

ran tests and linting with `nox`
