### PR TITLE
[setup] Add exclude-newer = "3 days ago" to guard against supply chain attacks

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,9 +16,9 @@ UV_NIGHTLY_ENV_VARS = {
 # as suggested by uv's own hint, for numpy and scipy only.
 NIGHTLY_EXCLUDE_NEWER_OVERRIDES = [
     "--exclude-newer-package",
-    "numpy=9999-12-31",
+    "numpy=2099-12-31",
     "--exclude-newer-package",
-    "scipy=9999-12-31",
+    "scipy=2099-12-31",
 ]
 
 nox.needs_version = ">=2024.4.15"

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,19 +7,8 @@ UV_NIGHTLY_ENV_VARS = {
     "UV_INDEX_URL": NIGHTLY_INDEX_URL,
     "UV_PRERELEASE": "allow",
     "UV_INDEX_STRATEGY": "first-index",
+    "UV_NO_CONFIG": "1",
 }
-
-# The nightly wheels at scientific-python-nightly-wheels are published without
-# upload-date metadata, so the pyproject.toml `exclude-newer` supply-chain guard
-# filters them out (raising the global cutoff doesn't help — uv treats dateless
-# wheels as at-the-cutoff). Override per-package via `--exclude-newer-package`,
-# as suggested by uv's own hint, for numpy and scipy only.
-NIGHTLY_EXCLUDE_NEWER_OVERRIDES = [
-    "--exclude-newer-package",
-    "numpy=2099-12-31",
-    "--exclude-newer-package",
-    "scipy=2099-12-31",
-]
 
 nox.needs_version = ">=2024.4.15"
 nox.options.default_venv_backend = "uv|virtualenv"
@@ -70,7 +59,6 @@ def run_nightly_tests(session):
             "--upgrade",
             "--only-binary",
             ":all:",
-            *NIGHTLY_EXCLUDE_NEWER_OVERRIDES,
             silent=False,
             env=UV_NIGHTLY_ENV_VARS,
         )
@@ -81,7 +69,6 @@ def run_nightly_tests(session):
             "--upgrade",
             "--only-binary",
             ":all:",
-            *NIGHTLY_EXCLUDE_NEWER_OVERRIDES,
             silent=False,
             env=UV_NIGHTLY_ENV_VARS,
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,9 @@ UV_NIGHTLY_ENV_VARS = {
     "UV_INDEX_URL": NIGHTLY_INDEX_URL,
     "UV_PRERELEASE": "allow",
     "UV_INDEX_STRATEGY": "first-index",
+    # Override the pyproject.toml `exclude-newer` supply-chain guard so the
+    # nightly session can resolve fresh dev wheels of numpy/scipy.
+    "UV_EXCLUDE_NEWER": "2099-12-31",
 }
 
 nox.needs_version = ">=2024.4.15"

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,10 +7,17 @@ UV_NIGHTLY_ENV_VARS = {
     "UV_INDEX_URL": NIGHTLY_INDEX_URL,
     "UV_PRERELEASE": "allow",
     "UV_INDEX_STRATEGY": "first-index",
-    # Override the pyproject.toml `exclude-newer` supply-chain guard so the
-    # nightly session can resolve fresh dev wheels of numpy/scipy.
-    "UV_EXCLUDE_NEWER": "2099-12-31",
 }
+
+# The nightly wheels at scientific-python-nightly-wheels are published without
+# upload-date metadata, so the pyproject.toml `exclude-newer` supply-chain guard
+# filters them out (raising the global cutoff doesn't help — uv treats dateless
+# wheels as at-the-cutoff). Override per-package via `--exclude-newer-package`,
+# as suggested by uv's own hint, for numpy and scipy only.
+NIGHTLY_EXCLUDE_NEWER_OVERRIDES = [
+    "--exclude-newer-package", "numpy=9999-12-31",
+    "--exclude-newer-package", "scipy=9999-12-31",
+]
 
 nox.needs_version = ">=2024.4.15"
 nox.options.default_venv_backend = "uv|virtualenv"
@@ -57,10 +64,14 @@ def run_nightly_tests(session):
     # SciPy doesn't have wheels on PyPy
     if platform.python_implementation() == "PyPy":
         session.install(
-            "numpy", "--upgrade", "--only-binary", ":all:", silent=False, env=UV_NIGHTLY_ENV_VARS
+            "numpy", "--upgrade", "--only-binary", ":all:",
+            *NIGHTLY_EXCLUDE_NEWER_OVERRIDES,
+            silent=False, env=UV_NIGHTLY_ENV_VARS,
         )
     else:
         session.install(
-            "numpy", "scipy", "--upgrade", "--only-binary", ":all:", silent=False, env=UV_NIGHTLY_ENV_VARS
+            "numpy", "scipy", "--upgrade", "--only-binary", ":all:",
+            *NIGHTLY_EXCLUDE_NEWER_OVERRIDES,
+            silent=False, env=UV_NIGHTLY_ENV_VARS,
         )
     session.run("pytest", "--cov=autograd", "--cov-report=xml", "--cov-append", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,8 +15,10 @@ UV_NIGHTLY_ENV_VARS = {
 # wheels as at-the-cutoff). Override per-package via `--exclude-newer-package`,
 # as suggested by uv's own hint, for numpy and scipy only.
 NIGHTLY_EXCLUDE_NEWER_OVERRIDES = [
-    "--exclude-newer-package", "numpy=9999-12-31",
-    "--exclude-newer-package", "scipy=9999-12-31",
+    "--exclude-newer-package",
+    "numpy=9999-12-31",
+    "--exclude-newer-package",
+    "scipy=9999-12-31",
 ]
 
 nox.needs_version = ">=2024.4.15"
@@ -64,14 +66,23 @@ def run_nightly_tests(session):
     # SciPy doesn't have wheels on PyPy
     if platform.python_implementation() == "PyPy":
         session.install(
-            "numpy", "--upgrade", "--only-binary", ":all:",
+            "numpy",
+            "--upgrade",
+            "--only-binary",
+            ":all:",
             *NIGHTLY_EXCLUDE_NEWER_OVERRIDES,
-            silent=False, env=UV_NIGHTLY_ENV_VARS,
+            silent=False,
+            env=UV_NIGHTLY_ENV_VARS,
         )
     else:
         session.install(
-            "numpy", "scipy", "--upgrade", "--only-binary", ":all:",
+            "numpy",
+            "scipy",
+            "--upgrade",
+            "--only-binary",
+            ":all:",
             *NIGHTLY_EXCLUDE_NEWER_OVERRIDES,
-            silent=False, env=UV_NIGHTLY_ENV_VARS,
+            silent=False,
+            env=UV_NIGHTLY_ENV_VARS,
         )
     session.run("pytest", "--cov=autograd", "--cov-report=xml", "--cov-append", *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ test = [
 ]
 examples = ["matplotlib"]
 
+[tool.uv]
+exclude-newer = "3 days ago"
+
 [tool.coverage.run]
 source = ["autograd"]
 


### PR DESCRIPTION
I propose to skip new package releases for 3 days by default via the exclude-newer uv option, to guard against supply chain attacks which have become more frequenty in recent months.