### PR TITLE
[Fix] Added **kwargs to autograd's reduction gradient functions

### DIFF
--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -162,7 +162,9 @@ defjvp(anp.sum, "same")
 defjvp(anp._primitive_mean, "same")
 defjvp(
     anp.prod,
-    lambda g, ans, x, axis=None, keepdims=False, **kwargs: ans * anp.sum(g / x, axis=axis, keepdims=keepdims),
+    lambda g, ans, x, axis=None, keepdims=False, **kwargs: (
+        ans * anp.sum(g / x, axis=axis, keepdims=keepdims)
+    ),
 )
 defjvp(
     anp.linspace,

--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -161,7 +161,8 @@ defjvp(anp.transpose, "same")
 defjvp(anp.sum, "same")
 defjvp(anp._primitive_mean, "same")
 defjvp(
-    anp.prod, lambda g, ans, x, axis=None, keepdims=False: ans * anp.sum(g / x, axis=axis, keepdims=keepdims)
+    anp.prod,
+    lambda g, ans, x, axis=None, keepdims=False, **kwargs: ans * anp.sum(g / x, axis=axis, keepdims=keepdims),
 )
 defjvp(
     anp.linspace,
@@ -202,7 +203,7 @@ def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
 defjvp(anp._primitive_std, forward_grad_np_std)
 
 
-def fwd_grad_chooser(g, ans, x, axis=None, keepdims=False):
+def fwd_grad_chooser(g, ans, x, axis=None, keepdims=False, **kwargs):
     if anp.isscalar(x):
         return g
     if not keepdims:

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -440,7 +440,7 @@ def grad_broadcast_to(ans, x, new_shape):
 defvjp(anp.broadcast_to, grad_broadcast_to)
 
 
-def grad_np_sum(ans, x, axis=None, keepdims=False, dtype=None):
+def grad_np_sum(ans, x, axis=None, keepdims=False, dtype=None, **kwargs):
     shape, dtype = anp.shape(x), anp.result_type(x)
     return lambda g: repeat_to_match_shape(g, shape, dtype, axis, keepdims)[0]
 
@@ -461,7 +461,7 @@ def grad_np_mean(ans, x, axis=None, keepdims=False, **kwargs):
 defvjp(anp._primitive_mean, grad_np_mean)
 
 
-def grad_np_prod(ans, x, axis=None, keepdims=False):  # TODO: Support tuples of axes.
+def grad_np_prod(ans, x, axis=None, keepdims=False, **kwargs):  # TODO: Support tuples of axes.
     shape, dtype = anp.shape(x), anp.result_type(x)
 
     def vjp(g):
@@ -512,7 +512,7 @@ def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
 defvjp(anp._primitive_std, grad_np_std)
 
 
-def grad_chooser(ans, x, axis=None, keepdims=None):
+def grad_chooser(ans, x, axis=None, keepdims=None, **kwargs):
     shape, dtype = anp.shape(x), anp.result_type(x)
 
     def vjp(g):

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -169,6 +169,7 @@ def test_plain_numpy_reductions_on_box():
         (onp.max, np.max),
         (onp.min, np.min),
     ]:
+
         def fun_plain(a, _r=onp_reduction):
             return _r(np.exp(a) * base)
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -154,6 +154,31 @@ def test_sum_with_axis_tuple():
     check_grads(fun)(mat)
 
 
+def test_plain_numpy_reductions_on_box():
+    # Regression test: calling a *plain* numpy reduction (numpy.sum/prod/max/min)
+    # on an ArrayBox routes through numpy's _wrapreduction, which forwards an
+    # ``out=None`` keyword to the wrapped primitive (and thus to its VJP). The
+    # reduction VJPs must tolerate this extra keyword argument.
+    import numpy as onp
+
+    base = onp.abs(npr.randn(5)) + 0.5
+
+    for onp_reduction, anp_reduction in [
+        (onp.sum, np.sum),
+        (onp.prod, np.prod),
+        (onp.max, np.max),
+        (onp.min, np.min),
+    ]:
+        def fun_plain(a, _r=onp_reduction):
+            return _r(np.exp(a) * base)
+
+        def fun_autograd(a, _r=anp_reduction):
+            return _r(np.exp(a) * base)
+
+        check_grads(fun_plain)(0.7)
+        assert onp.isclose(grad(fun_plain)(0.7), grad(fun_autograd)(0.7))
+
+
 def test_flipud():
     def fun(x):
         return np.flipud(x)


### PR DESCRIPTION
As a follow-up to @danra's change in https://github.com/HIPS/autograd/pull/717 I found a few edge cases that trigger a `TypeError` when trying to diff a reduction operation on an arraybox as numpy injects `out=None`. I added a test-case that fails on v1.9.0. The fix is to simply set `**kwargs` for the respective gradient functions.