### PR TITLE
Share the node when copying `Box`es

### DIFF
--- a/autograd/tracer.py
+++ b/autograd/tracer.py
@@ -173,6 +173,12 @@ class Box:
     def __str__(self):
         return f"Autograd {type(self).__name__} with value {self._value!s}"
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
+
     @classmethod
     def register(cls, value_type):
         Box.types.add(cls)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 """This file doesn't import the numpy wrapper, to check if core works
 on basic operations even without numpy."""
 
+import copy
 import warnings
 
 from autograd.core import make_vjp
@@ -80,3 +81,26 @@ def test_lt():
 
 def test_gt():
     check_binary_func(lambda x, y: x > y, independent=True)
+
+
+def test_copy():
+    # copy.copy of a box must not duplicate its node, otherwise the trace is
+    # split into disconnected pieces and only one of them reaches the gradient.
+    check_close(grad(lambda x: copy.copy(x) + 2 * copy.copy(x))(1.5), 3.0)
+
+
+def test_deepcopy():
+    check_close(grad(lambda x: copy.deepcopy(x) + 2 * copy.deepcopy(x))(1.5), 3.0)
+
+
+def test_deepcopy_container():
+    def fun(x):
+        d = copy.deepcopy({"a": [x, x]})
+        assert d["a"][0] is d["a"][1] is x
+        return d["a"][0] * d["a"][1]
+
+    check_close(grad(fun)(1.5), 3.0)
+
+
+def test_deepcopy_higher_order():
+    check_close(grad(grad(lambda x: copy.deepcopy(x) ** 3))(2.0), 12.0)

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -1,3 +1,4 @@
+import copy
 import warnings
 
 import pytest
@@ -189,6 +190,15 @@ def test_assignment_raises_error():
     A = npr.randn(5)
     with pytest.raises(TypeError):
         check_grads(fun)(A, 3.0)
+
+
+def test_grad_deepcopy():
+    def fun(x):
+        return sum(i * np.sum(copy.deepcopy(x)) for i in range(1, 3))
+
+    A = npr.randn(5)
+    assert np.allclose(grad(fun)(A), 3.0)
+    check_grads(fun)(A)
 
 
 # def test_nonscalar_output_1():


### PR DESCRIPTION
Closes #555

The node should not be cloned along with the value when deepcopying. Otherwise, each copy starts its own disconnected graph, and the backward pass returns the outgrad of whichever root is visited last by the toposort.

As far as tracing is concerned, `Box`es are immutable. So the `__copy__` here should keep the same behaviour for copies of containers containing boxes.