### PR TITLE
Fix the derivatives of `np.pad` for the default mode

### DIFF
--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -301,4 +301,7 @@ def broadcast(x, target):
     return x
 
 
-defjvp(anp.pad, lambda g, ans, array, width, mode, **kwargs: anp.pad(g, width, mode))
+defjvp(
+    anp.pad,
+    lambda g, ans, array, width, mode="constant", **kwargs: anp.pad(g, width, mode),
+)

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -968,7 +968,7 @@ def _unpad(array, width):
     return array[idxs]
 
 
-def pad_vjp(ans, array, pad_width, mode, **kwargs):
+def pad_vjp(ans, array, pad_width, mode="constant", **kwargs):
     assert mode == "constant", "Only constant mode padding is supported."
     return lambda g: _unpad(g, pad_width)
 

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -632,3 +632,10 @@ def test_pad():
     combo_check(np.pad, [0])(
         [R(2, 2)], [0, 3, (3,), (3, 2), ((3, 2),), ((1, 2), (3, 4)), ((0, 0), (0, 0))], ["constant"]
     )
+
+
+def test_pad_default_mode():
+    # The mode argument of np.pad is optional and defaults to "constant",
+    # so the derivatives must be defined for calls that do not pass it.
+    combo_check(np.pad, [0])([R(2, 2)], [0, 3, (3,), (3, 2), ((3, 2),), ((1, 2), (3, 4)), ((0, 0), (0, 0))])
+    combo_check(np.pad, [0])([R(2, 2)], [2], constant_values=[0.0, 5.0])


### PR DESCRIPTION
`np.pad` takes `mode` as an optional argument that defaults to `"constant"`, but the
derivatives of `np.pad` declared it as a required positional argument. The most common
call therefore raised a `TypeError`:

```python
import numpy as np
import autograd.numpy as anp
from autograd import grad

grad(lambda x: anp.sum(anp.pad(x, 2)))(np.ones(4))
# TypeError: pad_vjp() missing 1 required positional argument: 'mode'
```

Forward mode failed the same way, and so did calls that only use keyword arguments of
`np.pad`, e.g. `anp.pad(x, 2, constant_values=5.0)`. Passing the mode explicitly, which is
what the tests and the reports in #429/#431/#441 did, worked.

This defaults `mode` to `"constant"` in `pad_vjp` and in the JVP lambda, matching numpy's
signature, so the derivatives work whether the mode is omitted, passed positionally or
passed as a keyword. Other modes still hit the existing assertion
(`Only constant mode padding is supported.`), which is unchanged.

### Tests

`test_pad_default_mode` runs the same combination of array shapes and `pad_width`s as
`test_pad` but without a `mode` argument, so it covers the default. It also covers
`constant_values`, which only reachable through keyword arguments. Since `combo_check`
compares against numerical derivatives in both forward and reverse mode (including
second order), the test fails on `main` with

```
TypeError: <lambda>() missing 1 required positional argument: 'mode'
```

and passes with this change. The full test suite is unaffected:

```
$ pytest tests/test_systematic.py -k pad
2 passed
$ pytest tests/ -q
633 passed, 13 skipped     # 632 passed, 13 skipped before this change (the new test)
```

`ruff` and `ruff-format` are clean on the changed files.
