### PR TITLE
Take the `where` argument of reductions into account

### DIFF
--- a/autograd/numpy/numpy_jvps.py
+++ b/autograd/numpy/numpy_jvps.py
@@ -11,6 +11,7 @@ from .numpy_vjps import (
     dot_adjoint_1,
     match_complex,
     nograd_functions,
+    reduction_mask,
     replace_zero,
     tensordot_adjoint_0,
     tensordot_adjoint_1,
@@ -161,12 +162,18 @@ defjvp(anp.tile, "same")
 defjvp(anp.transpose, "same")
 defjvp(anp.sum, "same")
 defjvp(anp._primitive_mean, "same")
-defjvp(
-    anp.prod,
-    lambda g, ans, x, axis=None, keepdims=False, **kwargs: (
-        ans * anp.sum(g / x, axis=axis, keepdims=keepdims)
-    ),
-)
+
+
+def fwd_grad_prod(g, ans, x, axis=None, keepdims=False, where=None, **kwargs):
+    mask = reduction_mask(where, anp.shape(x))
+    if mask is None:
+        return ans * anp.sum(g / x, axis=axis, keepdims=keepdims)
+    # The excluded elements are not part of the product, so they can hold any
+    # value, including zero: replace them before dividing by x.
+    return ans * anp.sum(g * mask / anp.where(mask, x, 1.0), axis=axis, keepdims=keepdims)
+
+
+defjvp(anp.prod, fwd_grad_prod)
 defjvp(
     anp.linspace,
     lambda g, ans, start, stop, *args, **kwargs: anp.linspace(g, 0, *args, **kwargs),
@@ -174,7 +181,17 @@ defjvp(
 )
 
 
-def forward_grad_np_var(g, ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
+def forward_grad_np_var(g, ans, x, axis=None, ddof=0, keepdims=False, where=None, **kwargs):
+    mask = reduction_mask(where, anp.shape(x))
+    if mask is not None:
+        num_reps = anp.sum(mask, axis=axis, keepdims=keepdims)
+        x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True, where=where))
+        return (
+            2.0
+            * anp.sum(anp.real(g * x_minus_mean) * mask, axis=axis, keepdims=keepdims)
+            / (num_reps - ddof)
+        )
+
     if axis is None:
         num_reps = anp.size(g)
     elif isinstance(axis, int):
@@ -189,7 +206,15 @@ def forward_grad_np_var(g, ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
 defjvp(anp._primitive_var, forward_grad_np_var)
 
 
-def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
+def forward_grad_np_std(g, ans, x, axis=None, ddof=0, keepdims=False, where=None, **kwargs):
+    mask = reduction_mask(where, anp.shape(x))
+    if mask is not None:
+        num_reps = anp.sum(mask, axis=axis, keepdims=keepdims)
+        x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True, where=where))
+        return anp.sum(anp.real(g * x_minus_mean) * mask, axis=axis, keepdims=keepdims) / (
+            (num_reps - ddof) * ans
+        )
+
     if axis is None:
         num_reps = anp.size(g)
     elif isinstance(axis, int):

--- a/autograd/numpy/numpy_vjps.py
+++ b/autograd/numpy/numpy_vjps.py
@@ -441,20 +441,47 @@ def grad_broadcast_to(ans, x, new_shape):
 defvjp(anp.broadcast_to, grad_broadcast_to)
 
 
-def grad_np_sum(ans, x, axis=None, keepdims=False, dtype=None, **kwargs):
+def reduction_mask(where, shape):
+    """Broadcast the ``where`` mask of a reduction to the shape of its input.
+
+    A reduction with a ``where`` argument only looks at the selected elements,
+    so its derivatives have to skip the others: otherwise the gradient is
+    non-zero for an element that the result does not depend on.
+    """
+    if where is None:
+        return None
+    return anp.zeros(shape, dtype=bool) + where
+
+
+def grad_np_sum(ans, x, axis=None, keepdims=False, dtype=None, where=None, **kwargs):
     shape, dtype = anp.shape(x), anp.result_type(x)
-    return lambda g: repeat_to_match_shape(g, shape, dtype, axis, keepdims)[0]
+
+    def vjp(g):
+        g_repeated, _ = repeat_to_match_shape(g, shape, dtype, axis, keepdims)
+        mask = reduction_mask(where, shape)
+        if mask is None:
+            return g_repeated
+        return g_repeated * mask
+
+    return vjp
 
 
 defvjp(anp.sum, grad_np_sum)
 
 
-def grad_np_mean(ans, x, axis=None, keepdims=False, **kwargs):
+def grad_np_mean(ans, x, axis=None, keepdims=False, where=None, **kwargs):
     shape, dtype = anp.shape(x), anp.result_type(x)
 
     def vjp(g):
         g_repeated, num_reps = repeat_to_match_shape(g, shape, dtype, axis, keepdims)
-        return g_repeated / num_reps
+        mask = reduction_mask(where, shape)
+        if mask is None:
+            return g_repeated / num_reps
+        # The mean of the selected elements divides by their number, which is
+        # not the number of elements of the reduced axes. Keep the reduced axes
+        # in the count so that it broadcasts against the input.
+        count = anp.sum(mask, axis=axis, keepdims=True)
+        return g_repeated * mask / count
 
     return vjp
 
@@ -462,12 +489,17 @@ def grad_np_mean(ans, x, axis=None, keepdims=False, **kwargs):
 defvjp(anp._primitive_mean, grad_np_mean)
 
 
-def grad_np_prod(ans, x, axis=None, keepdims=False, **kwargs):  # TODO: Support tuples of axes.
+def grad_np_prod(ans, x, axis=None, keepdims=False, where=None, **kwargs):  # TODO: Support tuples of axes.
     shape, dtype = anp.shape(x), anp.result_type(x)
 
     def vjp(g):
         g_repeated, _ = repeat_to_match_shape(g * ans, shape, dtype, axis, keepdims)
-        return g_repeated / x
+        mask = reduction_mask(where, shape)
+        if mask is None:
+            return g_repeated / x
+        # The excluded elements are not part of the product, so they can hold
+        # any value, including zero: replace them before dividing by x.
+        return g_repeated / anp.where(mask, x, 1.0) * mask
 
     return vjp
 
@@ -475,15 +507,20 @@ def grad_np_prod(ans, x, axis=None, keepdims=False, **kwargs):  # TODO: Support 
 defvjp(anp.prod, grad_np_prod)
 
 
-def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
+def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False, where=None, **kwargs):
     shape, _, dtype, iscomplex = anp.metadata(x)
 
     def vjp(g):
         if iscomplex:
             g = g + 0j
         g_repeated, num_reps = repeat_to_match_shape(g, shape, dtype, axis, keepdims)
-        x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True))
-        return 2.0 * g_repeated * x_minus_mean / (num_reps - ddof)
+        mask = reduction_mask(where, shape)
+        if mask is None:
+            x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True))
+            return 2.0 * g_repeated * x_minus_mean / (num_reps - ddof)
+        num_reps = anp.sum(mask, axis=axis, keepdims=True)
+        x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True, where=where))
+        return 2.0 * g_repeated * x_minus_mean * mask / (num_reps - ddof)
 
     return vjp
 
@@ -491,7 +528,7 @@ def grad_np_var(ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
 defvjp(anp._primitive_var, grad_np_var)
 
 
-def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
+def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False, where=None, **kwargs):
     shape, _, dtype, iscomplex = anp.metadata(x)
 
     def vjp(g):
@@ -500,12 +537,17 @@ def grad_np_std(ans, x, axis=None, ddof=0, keepdims=False, **kwargs):
         g_repeated, num_reps = repeat_to_match_shape(
             g, shape, dtype, axis, keepdims
         )  # Avoid division by zero.
-        if num_reps <= 1:
-            return g_repeated * 0.0
-        else:
+        mask = reduction_mask(where, shape)
+        if mask is None:
+            if num_reps <= 1:
+                return g_repeated * 0.0
             g_repeated, num_reps = repeat_to_match_shape(g / ans, shape, dtype, axis, keepdims)
             x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True))
             return g_repeated * x_minus_mean / (num_reps - ddof)
+        num_reps = anp.sum(mask, axis=axis, keepdims=True)
+        g_repeated, _ = repeat_to_match_shape(g / ans, shape, dtype, axis, keepdims)
+        x_minus_mean = anp.conj(x - anp.mean(x, axis=axis, keepdims=True, where=where))
+        return g_repeated * mask * x_minus_mean / (num_reps - ddof)
 
     return vjp
 

--- a/tests/test_systematic.py
+++ b/tests/test_systematic.py
@@ -5,7 +5,8 @@ from numpy_utils import binary_ufunc_check, binary_ufunc_check_no_same_args, sta
 
 import autograd.numpy as np
 import autograd.numpy.random as npr
-from autograd.test_util import combo_check
+from autograd import grad
+from autograd.test_util import check_grads, combo_check
 
 npr.seed(0)
 
@@ -632,3 +633,46 @@ def test_pad():
     combo_check(np.pad, [0])(
         [R(2, 2)], [0, 3, (3,), (3, 2), ((3, 2),), ((1, 2), (3, 4)), ((0, 0), (0, 0))], ["constant"]
     )
+
+
+def test_reductions_with_where():
+    # A reduction with a `where` argument ignores the elements it excludes, so
+    # the derivatives must give them a zero gradient.
+    mask = onp.array(
+        [
+            [True, True, False, True],
+            [True, False, True, True],
+            [False, True, True, True],
+        ]
+    )
+    # `where` may also be broadcast against the input instead of matching its
+    # shape, as long as no slice of the reduction is left empty.
+    broadcast_mask = onp.array([True, True, False, True])
+    for fun in [np.sum, np.mean, np.prod]:
+        combo_check(fun, [0])([R(3, 4)], where=[mask], axis=[None, 0, 1], keepdims=[True, False])
+        combo_check(fun, [0])([R(3, 4)], where=[broadcast_mask], axis=[None, 1], keepdims=[True, False])
+    for fun in [np.var, np.std]:
+        combo_check(fun, [0])(
+            [R(3, 4)],
+            where=[mask],
+            axis=[None, 0, 1],
+            keepdims=[True, False],
+            ddof=[0, 1],
+        )
+        combo_check(fun, [0])(
+            [R(3, 4)],
+            where=[broadcast_mask],
+            axis=[None, 1],
+            keepdims=[True, False],
+            ddof=[0, 1],
+        )
+
+
+def test_reduction_where_is_skipped():
+    # The gradient of an excluded element must be zero, whatever the reduction.
+    x = onp.array([1.0, 2.0, 3.0, 4.0])
+    mask = onp.array([True, False, True, True])
+    for fun in [np.sum, np.mean, np.prod, np.var, np.std]:
+        f = lambda a, fun=fun: fun(a, where=mask)
+        check_grads(f, modes=["fwd", "rev"])(x)
+        assert np.allclose(grad(f)(x)[1], 0.0)


### PR DESCRIPTION
The derivatives of the reductions accepted a `where` argument but ignored it, so they
returned a **wrong gradient** instead of an error. Every element received the derivative
of a reduction that only looks at the selected ones:

```python
import numpy as np
import autograd.numpy as anp
from autograd import grad

x = np.array([1.0, 2.0, 3.0, 4.0])
mask = np.array([True, False, True, True])

grad(lambda z: anp.sum(z, where=mask, initial=0.0))(x)
# array([1., 1., 1., 1.])   but the second element is not part of the sum, so it should be 0
```

This is the kind of bug an autodiff library should not have: the value is right, the
gradient is wrong, and nothing warns. It affects `sum`, `mean`, `prod`, `var` and `std`,
in both forward and reverse mode (`prod`, `var` and `std` were wrong in forward mode too).

The fix multiplies the cotangent by the mask, and:

- `mean` divides by the number of *selected* elements, not by the number of elements of
  the reduced axes, which is what numpy does;
- `var` and `std` use the mean and the count of the selected elements, so the `ddof`
  correction applies to the same count as in the value;
- `prod` replaces the excluded elements before dividing by `x`, since an excluded element
  can be anything, including zero, and would otherwise produce `nan`/`inf`;
- the count keeps the reduced dimensions (`keepdims=True` internally) so it broadcasts
  against the input for reductions over an axis rather than over the whole array.

Everything without a `where` argument goes through the previous code path unchanged.

### Tests

`test_reductions_with_where` runs the reductions over both axes and `keepdims`, with a
`where` of the same shape as the input and with one that is only broadcastable to it, and
with `ddof` 0 and 1 for `var`/`std`. `test_reduction_where_is_skipped` pins the reported
bug down: the gradient of an excluded element is zero for all five reductions. Both fail
on `main` (`Derivative (VJP) check of jvp_sum failed`) and pass with this change.

```
$ pytest tests/ -q
634 passed, 13 skipped     # 632 passed, 13 skipped before this change
```

`ruff` and `ruff-format` are clean.
